### PR TITLE
Management packets refactoring, support dynamic Management TLV extension

### DIFF
--- a/protocol/management_tlvs.go
+++ b/protocol/management_tlvs.go
@@ -1,0 +1,243 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// ManagementID is type for Management IDs
+type ManagementID uint16
+
+// Management IDs we support, from Table 59 managementId values
+const (
+	IDNullPTPManagement        ManagementID = 0x0000
+	IDClockDescription         ManagementID = 0x0001
+	IDUserDescription          ManagementID = 0x0002
+	IDSaveInNonVolatileStorage ManagementID = 0x0003
+	IDResetNonVolatileStorage  ManagementID = 0x0004
+	IDInitialize               ManagementID = 0x0005
+	IDFaultLog                 ManagementID = 0x0006
+	IDFaultLogReset            ManagementID = 0x0007
+
+	IDDefaultDataSet        ManagementID = 0x2000
+	IDCurrentDataSet        ManagementID = 0x2001
+	IDParentDataSet         ManagementID = 0x2002
+	IDTimePropertiesDataSet ManagementID = 0x2003
+	IDPortDataSet           ManagementID = 0x2004
+	// rest of Management IDs that we don't implement yet
+)
+
+// ManagementTLV abstracts away any ManagementTLV
+type ManagementTLV interface {
+	TLV
+	MgmtID() ManagementID
+}
+
+// MgmtTLVDecoderFunc is the function we use to decode management TLV from bytes
+type MgmtTLVDecoderFunc func(data []byte) (ManagementTLV, error)
+
+// default decoders for TLVs we implemented ourselves
+var mgmtTLVDecoder = map[ManagementID]MgmtTLVDecoderFunc{
+	IDDefaultDataSet: func(data []byte) (ManagementTLV, error) {
+		r := bytes.NewReader(data)
+		tlv := &DefaultDataSetTLV{}
+		if err := binary.Read(r, binary.BigEndian, tlv); err != nil {
+			return nil, err
+		}
+		return tlv, nil
+	},
+	IDCurrentDataSet: func(data []byte) (ManagementTLV, error) {
+		r := bytes.NewReader(data)
+		tlv := &CurrentDataSetTLV{}
+		if err := binary.Read(r, binary.BigEndian, tlv); err != nil {
+			return nil, err
+		}
+		return tlv, nil
+	},
+	IDParentDataSet: func(data []byte) (ManagementTLV, error) {
+		r := bytes.NewReader(data)
+		tlv := &ParentDataSetTLV{}
+		if err := binary.Read(r, binary.BigEndian, tlv); err != nil {
+			return nil, err
+		}
+		return tlv, nil
+	},
+	IDPortStatsNP: func(data []byte) (ManagementTLV, error) {
+		r := bytes.NewReader(data)
+		tlv := &PortStatsNPTLV{}
+		if err := binary.Read(r, binary.BigEndian, &tlv.ManagementTLVHead); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(r, binary.BigEndian, &tlv.PortIdentity); err != nil {
+			return nil, err
+		}
+		// fun part that cost me few hours, this is sent over wire as LittlEndian, while EVERYTHING ELSE is BigEndian.
+		if err := binary.Read(r, binary.LittleEndian, &tlv.PortStats); err != nil {
+			return nil, err
+		}
+		return tlv, nil
+	},
+	IDTimeStatusNP: func(data []byte) (ManagementTLV, error) {
+		r := bytes.NewReader(data)
+		tlv := &TimeStatusNPTLV{}
+		if err := binary.Read(r, binary.BigEndian, tlv); err != nil {
+			return nil, err
+		}
+		return tlv, nil
+	},
+}
+
+// RegisterMgmtTLVDecoder registers function we'll use to decode particular custom management TLV.
+// IEEE1588-2019 specifies that range C000 – DFFF should be used for implementation-specific identifiers,
+// and E000 – FFFE is to be assigned by alternate PTP Profile.
+func RegisterMgmtTLVDecoder(id ManagementID, decoder MgmtTLVDecoderFunc) {
+	mgmtTLVDecoder[id] = decoder
+}
+
+// CurrentDataSetTLV Spec Table 84 - CURRENT_DATA_SET management TLV data field
+type CurrentDataSetTLV struct {
+	ManagementTLVHead
+
+	StepsRemoved     uint16
+	OffsetFromMaster TimeInterval
+	MeanPathDelay    TimeInterval
+}
+
+// DefaultDataSetTLV Spec Table 69 - DEFAULT_DATA_SET management TLV data field
+type DefaultDataSetTLV struct {
+	ManagementTLVHead
+
+	SoTSC         uint8
+	Reserved0     uint8
+	NumberPorts   uint16
+	Priority1     uint8
+	ClockQuality  ClockQuality
+	Priority2     uint8
+	ClockIdentity ClockIdentity
+	DomainNumber  uint8
+	Reserved1     uint8
+}
+
+// ParentDataSetTLV Spec Table 85 - PARENT_DATA_SET management TLV data field
+type ParentDataSetTLV struct {
+	ManagementTLVHead
+
+	ParentPortIdentity                    PortIdentity
+	PS                                    uint8
+	Reserved                              uint8
+	ObservedParentOffsetScaledLogVariance uint16
+	ObservedParentClockPhaseChangeRate    uint32
+	GrandmasterPriority1                  uint8
+	GrandmasterClockQuality               ClockQuality
+	GrandmasterPriority2                  uint8
+	GrandmasterIdentity                   ClockIdentity
+}
+
+// CurrentDataSetRequest prepares request packet for CURRENT_DATA_SET request
+func CurrentDataSetRequest() *Management {
+	headerSize := uint16(binary.Size(ManagementMsgHead{}))
+	size := uint16(binary.Size(CurrentDataSetTLV{}))
+	tlvHeadSize := uint16(binary.Size(TLVHead{}))
+	return &Management{
+		ManagementMsgHead: ManagementMsgHead{
+			Header: Header{
+				SdoIDAndMsgType:    NewSdoIDAndMsgType(MessageManagement, 0),
+				Version:            Version,
+				MessageLength:      headerSize + size,
+				SourcePortIdentity: identity,
+				LogMessageInterval: MgmtLogMessageInterval,
+			},
+			TargetPortIdentity:   DefaultTargetPortIdentity,
+			StartingBoundaryHops: 0,
+			BoundaryHops:         0,
+			ActionField:          GET,
+		},
+		TLV: &CurrentDataSetTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: size - tlvHeadSize,
+				},
+				ManagementID: IDCurrentDataSet,
+			},
+		},
+	}
+}
+
+// DefaultDataSetRequest prepares request packet for DEFAULT_DATA_SET request
+func DefaultDataSetRequest() *Management {
+	headerSize := uint16(binary.Size(ManagementMsgHead{}))
+	size := uint16(binary.Size(DefaultDataSetTLV{}))
+	tlvHeadSize := uint16(binary.Size(TLVHead{}))
+	return &Management{
+		ManagementMsgHead: ManagementMsgHead{
+			Header: Header{
+				SdoIDAndMsgType:    NewSdoIDAndMsgType(MessageManagement, 0),
+				Version:            Version,
+				MessageLength:      headerSize + size,
+				SourcePortIdentity: identity,
+				LogMessageInterval: MgmtLogMessageInterval,
+			},
+			TargetPortIdentity:   DefaultTargetPortIdentity,
+			StartingBoundaryHops: 0,
+			BoundaryHops:         0,
+			ActionField:          GET,
+		},
+		TLV: &DefaultDataSetTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: size - tlvHeadSize,
+				},
+				ManagementID: IDDefaultDataSet,
+			},
+		},
+	}
+}
+
+// ParentDataSetRequest prepares request packet for PARENT_DATA_SET request
+func ParentDataSetRequest() *Management {
+	headerSize := uint16(binary.Size(ManagementMsgHead{}))
+	size := uint16(binary.Size(ParentDataSetTLV{}))
+	tlvHeadSize := uint16(binary.Size(TLVHead{}))
+	return &Management{
+		ManagementMsgHead: ManagementMsgHead{
+			Header: Header{
+				SdoIDAndMsgType:    NewSdoIDAndMsgType(MessageManagement, 0),
+				Version:            Version,
+				MessageLength:      headerSize + size,
+				SourcePortIdentity: identity,
+				LogMessageInterval: MgmtLogMessageInterval,
+			},
+			TargetPortIdentity:   DefaultTargetPortIdentity,
+			StartingBoundaryHops: 0,
+			BoundaryHops:         0,
+			ActionField:          GET,
+		},
+		TLV: &ParentDataSetTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: size - tlvHeadSize,
+				},
+				ManagementID: IDParentDataSet,
+			},
+		},
+	}
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -40,9 +40,11 @@ const (
 	PortGeneral = 320
 )
 
-const mgmtLogMessageInterval LogInterval = 0x7f // as per Table 42 Values of logMessageInterval field
+// MgmtLogMessageInterval is the default LogInterval value used in Management packets
+const MgmtLogMessageInterval LogInterval = 0x7f // as per Table 42 Values of logMessageInterval field
 
-var defaultTargetPortIdentity = PortIdentity{
+// DefaultTargetPortIdentity is a port identity that means any port
+var DefaultTargetPortIdentity = PortIdentity{
 	ClockIdentity: 0xffffffffffffffff,
 	PortNumber:    0xffff,
 }
@@ -208,8 +210,7 @@ func Bytes(p Packet) ([]byte, error) {
 		return append(b, []byte{0, 0}...), err
 	}
 	var bytes bytes.Buffer
-	var err error
-	err = binary.Write(&bytes, binary.BigEndian, p)
+	err := binary.Write(&bytes, binary.BigEndian, p)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/ptp4l_test.go
+++ b/protocol/ptp4l_test.go
@@ -31,10 +31,10 @@ func Test_parseTimeStatusNP(t *testing.T) {
 		79, 96, 119, 80, 118, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		1, 36, 138, 7, 255, 254, 63, 48, 154, 0, 0,
 	}
-	packet := new(ManagementMsgTimeStatusNP)
+	packet := new(Management)
 	err := FromBytes(raw, packet)
 	require.Nil(t, err)
-	want := ManagementMsgTimeStatusNP{
+	want := Management{
 		ManagementMsgHead: ManagementMsgHead{
 			Header: Header{
 				SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageManagement, 0),
@@ -59,14 +59,14 @@ func Test_parseTimeStatusNP(t *testing.T) {
 			},
 			ActionField: RESPONSE,
 		},
-		ManagementTLVHead: ManagementTLVHead{
-			TLVHead: TLVHead{
-				TLVType:     TLVManagement,
-				LengthField: 52,
+		TLV: &TimeStatusNPTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: 52,
+				},
+				ManagementID: IDTimeStatusNP,
 			},
-			ManagementID: IDTimeStatusNP,
-		},
-		TimeStatusNP: TimeStatusNP{
 			MasterOffsetNS:             24536521,
 			IngressTimeNS:              1615472167079671311,
 			CumulativeScaledRateOffset: 0,

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -136,17 +136,25 @@ func (t TLVType) String() string {
 	return TLVTypeToString[t]
 }
 
+// IntFloat is a float64 stored in int64
+type IntFloat int64
+
+// Value decodes IntFloat to float64
+func (t IntFloat) Value() float64 {
+	return float64(t) / twoPow16
+}
+
 /*
 TimeInterval is the time interval expressed in nanoseconds, multiplied by 2**16.
 Positive or negative time intervals outside the maximum range of this data type shall be encoded as the largest
 positive and negative values of the data type, respectively.
 For example, 2.5 ns is expressed as 0000 0000 0002 8000 base 16
 */
-type TimeInterval int64
+type TimeInterval IntFloat
 
 // Nanoseconds decodes TimeInterval to human-understandable nanoseconds
 func (t TimeInterval) Nanoseconds() float64 {
-	return float64(t) / twoPow16
+	return IntFloat(t).Value()
 }
 
 func (t TimeInterval) String() string {
@@ -163,11 +171,11 @@ Correction is the value of the correction measured in nanoseconds and multiplied
 For example, 2.5 ns is represented as 0000 0000 0002 8000 base 16
 A value of one in all bits, except the most significant, of the field shall indicate that the correction is too big to be represented.
 */
-type Correction int64
+type Correction IntFloat
 
 // Nanoseconds decodes Correction to human-understandable nanoseconds
 func (t Correction) Nanoseconds() float64 {
-	return float64(t) / twoPow16
+	return IntFloat(t).Value()
 }
 
 func (t Correction) String() string {


### PR DESCRIPTION
## Summary

This diff refactors Management packets to be more generic, and adds `RegisterMgmtTLVDecoder` function to allow extending protocol with custom Management TLVs.

## Test Plan

unittests
