### PR TITLE
Fix ptpcheck trace with IPv4

### DIFF
--- a/simpleclient/client.go
+++ b/simpleclient/client.go
@@ -185,11 +185,11 @@ func (c *Client) setup(ctx context.Context, eg *errgroup.Group) error {
 
 	// addresses
 	// where to send to
-	genAddr, err := net.ResolveUDPAddr("udp6", net.JoinHostPort(c.cfg.Address, fmt.Sprintf("%d", ptp.PortGeneral)))
+	genAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(c.cfg.Address, fmt.Sprintf("%d", ptp.PortGeneral)))
 	if err != nil {
 		return err
 	}
-	eventAddr, err := net.ResolveUDPAddr("udp6", net.JoinHostPort(c.cfg.Address, fmt.Sprintf("%d", ptp.PortEvent)))
+	eventAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(c.cfg.Address, fmt.Sprintf("%d", ptp.PortEvent)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Simple fix to work with ipv4

## Test Plan

before:
```
abulimov@devvm834 ~/g/s/g/f/p/ptpcheck > sudo ./ptpcheck trace -S 127.0.0.1
INFO[0000] using ClockIdentity 4857dd.fffe.086488, talking to 127.0.0.1 using Two-Step Unicast PTPv2 protocol
No measurements collected
FATA[0000] address 127.0.0.1: no suitable address found
```

after:
```
abulimov@devvm834 ~/g/s/g/f/p/ptpcheck > sudo ./ptpcheck trace -S 127.0.0.1
INFO[0000] using ClockIdentity 4857dd.fffe.086488, talking to 127.0.0.1 using Two-Step Unicast PTPv2 protocol
WARN[0000] Failed to enable hardware timestamps on port 319, falling back to software timestamps
INFO[0000] client -> SIGNALING (for ANNOUNCE, seq=0)
```
