### PR TITLE
Optimize memory allocations in ptp4u

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     working_directory: /go/src/github.com/facebookincubator/ptp
     executor:
       name: go/default
-      tag: '1.14'
+      tag: '1.16'
     steps:
       - checkout
       - run: go get -v -t ./...
@@ -20,7 +20,7 @@ jobs:
     working_directory: /go/src/github.com/facebookincubator/ptp
     executor:
       name: go/default
-      tag: '1.14'
+      tag: '1.16'
     steps:
       - checkout
       - run: go get -v -t ./...
@@ -29,7 +29,7 @@ jobs:
     working_directory: /go/src/github.com/facebookincubator/ptp
     executor:
       name: go/default
-      tag: '1.14'
+      tag: '1.16'
     steps:
       - checkout
       - run: go get -v -t ./...

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/facebookincubator/ptp
 
-go 1.15
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/facebookincubator/ntp v0.0.0-20210521103724-845970bc8e6a // indirect
+	github.com/facebookincubator/ntp v0.0.0-20210521103724-845970bc8e6a
 	github.com/fatih/color v1.12.0
 	github.com/golang/mock v1.5.0
 	github.com/google/gopacket v1.1.19

--- a/protocol/timestamp_test.go
+++ b/protocol/timestamp_test.go
@@ -44,7 +44,10 @@ func Test_ReadTXtimestamp(t *testing.T) {
 	require.Nil(t, err)
 	defer conn.Close()
 
-	txts, attempts, err := ReadTXtimestamp(conn)
+	connFd, err := ConnFd(conn)
+	require.Nil(t, err)
+
+	txts, attempts, err := ReadTXtimestamp(connFd)
 	require.Equal(t, time.Time{}, txts)
 	require.Equal(t, maxTXTS, attempts)
 	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", maxTXTS), err)
@@ -55,7 +58,7 @@ func Test_ReadTXtimestamp(t *testing.T) {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
 	_, err = conn.WriteTo([]byte{}, addr)
 	require.Nil(t, err)
-	txts, attempts, err = ReadTXtimestamp(conn)
+	txts, attempts, err = ReadTXtimestamp(connFd)
 
 	require.NotEqual(t, time.Time{}, txts)
 	require.Equal(t, 1, attempts)

--- a/protocol/unicast.go
+++ b/protocol/unicast.go
@@ -43,24 +43,30 @@ type Signaling struct {
 	TLVs               []TLV
 }
 
-// MarshalBinary converts packet to []bytes
-func (p *Signaling) MarshalBinary() ([]byte, error) {
+// MarshalBinaryTo converts packet to bytes and writes those into provided buffer
+func (p *Signaling) MarshalBinaryTo(bytes io.Writer) error {
 	if len(p.TLVs) == 0 {
-		return nil, fmt.Errorf("no TLVs in Signaling message, at least one required")
+		return fmt.Errorf("no TLVs in Signaling message, at least one required")
 	}
-	var bytes bytes.Buffer
-	if err := binary.Write(&bytes, binary.BigEndian, p.Header); err != nil {
-		return nil, err
+	if err := binary.Write(bytes, binary.BigEndian, p.Header); err != nil {
+		return err
 	}
-	if err := binary.Write(&bytes, binary.BigEndian, p.TargetPortIdentity); err != nil {
-		return nil, err
+	if err := binary.Write(bytes, binary.BigEndian, p.TargetPortIdentity); err != nil {
+		return err
 	}
 	for _, tlv := range p.TLVs {
-		if err := binary.Write(&bytes, binary.BigEndian, tlv); err != nil {
-			return nil, err
+		if err := binary.Write(bytes, binary.BigEndian, tlv); err != nil {
+			return err
 		}
 	}
-	return bytes.Bytes(), nil
+	return nil
+}
+
+// MarshalBinary converts packet to []bytes
+func (p *Signaling) MarshalBinary() ([]byte, error) {
+	var bytes bytes.Buffer
+	err := p.MarshalBinaryTo(&bytes)
+	return bytes.Bytes(), err
 }
 
 // UnmarshalBinary parses []byte and populates struct fields

--- a/ptp4u/main.go
+++ b/ptp4u/main.go
@@ -47,6 +47,7 @@ func main() {
 	flag.BoolVar(&c.SHM, "shm", false, "Use Share Memory Segment to determine UTC offset periodically")
 	flag.IntVar(&c.Workers, "workers", 10, "Set the number of workers")
 	flag.IntVar(&c.MonitoringPort, "monitoringport", 8888, "Port to run monitoring server on")
+	flag.IntVar(&c.QueueSize, "queue", 1000000, "Size of the queue to send out packets")
 	flag.DurationVar(&c.MetricInterval, "metricinterval", 1*time.Minute, "Interval of resetting metrics")
 
 	flag.Parse()

--- a/ptp4u/server/config.go
+++ b/ptp4u/server/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	TimestampType  string
 	UTCOffset      time.Duration
 	Workers        int
+	QueueSize      int
 
 	clockIdentity ptp.ClockIdentity
 }

--- a/ptp4u/server/server.go
+++ b/ptp4u/server/server.go
@@ -39,6 +39,8 @@ type Server struct {
 	Stats  stats.Stats
 	sw     []*sendWorker
 
+	queue chan *SubscriptionClient
+
 	eventConn   *net.UDPConn
 	generalConn *net.UDPConn
 	clients     syncMapCli
@@ -64,16 +66,15 @@ func (s *Server) Start() error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	// Here we will put the tasks needed to be processed
+	s.queue = make(chan *SubscriptionClient, s.Config.QueueSize)
+
 	// start X workers
 	s.sw = make([]*sendWorker, s.Config.Workers)
 	for i := 0; i < s.Config.Workers; i++ {
-		// Create subscription channels for every worker.
-		// Here we will put the tasks needed to be processed
-		queue := make(chan *SubscriptionClient, 10000)
-		// Each worker to monitor own queue
 		s.sw[i] = &sendWorker{
 			id:     i,
-			queue:  queue,
+			queue:  s.queue,
 			config: s.Config,
 			stats:  s.Stats,
 		}
@@ -99,6 +100,7 @@ func (s *Server) Start() error {
 			<-time.After(s.Config.MetricInterval)
 			s.inventoryClients()
 			s.Stats.SetUTCOffset(int64(s.Config.UTCOffset.Seconds()))
+			s.Stats.SetWorkerQueue(int64(len(s.queue)))
 
 			s.Stats.Snapshot()
 			s.Stats.Reset()
@@ -122,25 +124,6 @@ func (s *Server) Start() error {
 	// Wait for ANY gorouine to finish
 	wg.Wait()
 	return fmt.Errorf("one of server routines finished")
-}
-
-// findLeastBusyWorkerID searches for the worker with the least load.
-// Because HW timestamping is a very slow operation it's extremely
-// important to balance load between workers not just by number of
-// clients, but by number of packets per interval.
-func (s *Server) findLeastBusyWorkerID() int {
-	// Determine which worker is the least busy
-	var leastBusyWorkerLoad int64
-	leastBusyWorkerID := 0
-
-	for id, worker := range s.sw {
-		if id == 0 || worker.load < leastBusyWorkerLoad {
-			leastBusyWorkerID = id
-			leastBusyWorkerLoad = worker.load
-		}
-	}
-	log.Debugf("leastBusyWorkerID: %d with load: %d", leastBusyWorkerID, leastBusyWorkerLoad)
-	return leastBusyWorkerID
 }
 
 // startEventListener launches the listener which listens to subscription requests
@@ -321,7 +304,7 @@ func (s *Server) handleGeneralMessage(request []byte, clientIP net.IP) {
 
 					sc := s.findSubscription(signaling.SourcePortIdentity, grantType)
 					if sc == nil {
-						sc = NewSubscriptionClient(s.sw[s.findLeastBusyWorkerID()], clientIP, grantType, s.Config, intervalt, expire)
+						sc = NewSubscriptionClient(s.queue, clientIP, grantType, s.Config, intervalt, expire)
 						s.registerSubscription(signaling.SourcePortIdentity, grantType, sc)
 					} else {
 						// Update existing subscription data

--- a/ptp4u/server/server_test.go
+++ b/ptp4u/server/server_test.go
@@ -26,32 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Testing conversion so if Packet structure changes we notice
-func TestServerFindLeastBusyWorkerID(t *testing.T) {
-	s := Server{
-		Config: &Config{Workers: 3},
-	}
-
-	s.sw = make([]*sendWorker, s.Config.Workers)
-	for i := 0; i < s.Config.Workers; i++ {
-		s.sw[i] = &sendWorker{}
-	}
-
-	require.Equal(t, 0, s.findLeastBusyWorkerID())
-
-	s.sw[0].load = 1234
-	require.Equal(t, 1, s.findLeastBusyWorkerID())
-
-	s.sw[1].load = 8
-	require.Equal(t, 2, s.findLeastBusyWorkerID())
-
-	s.sw[2].load = 100500
-	require.Equal(t, 1, s.findLeastBusyWorkerID())
-
-	s.sw[1].load = 1000000
-	require.Equal(t, 0, s.findLeastBusyWorkerID())
-}
-
 func TestServerRegisterSubscription(t *testing.T) {
 	var (
 		scE *SubscriptionClient
@@ -78,14 +52,14 @@ func TestServerRegisterSubscription(t *testing.T) {
 	require.Nil(t, scE)
 
 	// Add Sync. Check we got
-	scS = NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now())
+	scS = NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageSync, scS)
 	// Check Sync is saved
 	scT = s.findSubscription(pi, ptp.MessageSync)
 	require.Equal(t, scS, scT)
 
 	// Add announce. Check we have now both
-	scA = NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now())
+	scA = NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageAnnounce, scA)
 	// First check Sync
 	scT = s.findSubscription(pi, ptp.MessageSync)
@@ -95,7 +69,7 @@ func TestServerRegisterSubscription(t *testing.T) {
 	require.Equal(t, scA, scT)
 
 	// Override announce
-	scA = NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now())
+	scA = NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageAnnounce, scA)
 	// Check new Announce is saved
 	scT = s.findSubscription(pi, ptp.MessageAnnounce)
@@ -120,19 +94,19 @@ func TestServerInventoryClients(t *testing.T) {
 	s := Server{Config: c, Stats: st}
 	s.clients.init()
 
-	scS1 := NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
+	scS1 := NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi1, ptp.MessageSync, scS1)
 	scS1.running = true
 	s.inventoryClients()
 	require.Equal(t, 1, len(s.clients.keys()))
 
-	scA1 := NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now().Add(time.Minute))
+	scA1 := NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi1, ptp.MessageSync, scA1)
 	scA1.running = true
 	s.inventoryClients()
 	require.Equal(t, 1, len(s.clients.keys()))
 
-	scS2 := NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
+	scS2 := NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi2, ptp.MessageSync, scS2)
 	scS2.running = true
 	s.inventoryClients()

--- a/ptp4u/server/subscription_test.go
+++ b/ptp4u/server/subscription_test.go
@@ -36,11 +36,10 @@ func TestRunning(t *testing.T) {
 }
 
 func TestSubscriptionStart(t *testing.T) {
-	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 1 * time.Minute
 	expire := time.Now().Add(1 * time.Second)
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
+	sc := NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start()
 	time.Sleep(100 * time.Millisecond)
@@ -54,12 +53,11 @@ func TestSubscriptionStop(t *testing.T) {
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 10 * time.Millisecond
 	expire := time.Now().Add(1 * time.Second)
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
+	sc := NewSubscriptionClient(w.queue, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start()
 	time.Sleep(100 * time.Millisecond)
 	require.True(t, sc.Running())
-	require.Equal(t, int64(1000), w.load)
 	sc.Stop()
 	time.Sleep(100 * time.Millisecond)
 	require.False(t, sc.Running())
@@ -67,10 +65,7 @@ func TestSubscriptionStop(t *testing.T) {
 
 func TestSubscriptionflags(t *testing.T) {
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
-	sc := SubscriptionClient{
-		serverConfig: c,
-		interval:     time.Second,
-	}
+	sc := NewSubscriptionClient(nil, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Time{})
 
 	require.Equal(t, ptp.FlagUnicast|ptp.FlagTwoStep, sc.syncPacket().Header.FlagField)
 	require.Equal(t, ptp.FlagUnicast, sc.followupPacket(time.Now()).Header.FlagField)

--- a/ptp4u/server/worker_test.go
+++ b/ptp4u/server/worker_test.go
@@ -48,7 +48,7 @@ func TestWorkerQueue(t *testing.T) {
 
 	interval := time.Millisecond
 	expire := time.Now().Add(time.Millisecond)
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
+	sc := NewSubscriptionClient(queue, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
 
 	for i := 0; i < 10; i++ {
 		w.queue <- sc

--- a/ptp4u/stats/json.go
+++ b/ptp4u/stats/json.go
@@ -62,10 +62,9 @@ func (s *JSONStats) Snapshot() {
 	s.tx.copy(&s.report.tx)
 	s.rxSignaling.copy(&s.report.rxSignaling)
 	s.txSignaling.copy(&s.report.txSignaling)
-	s.workerLoad.copy(&s.report.workerLoad)
-	s.workerQueue.copy(&s.report.workerQueue)
 	s.txtsattempts.copy(&s.report.txtsattempts)
 	s.report.utcoffset = s.utcoffset
+	s.report.workerQueue = s.workerQueue
 }
 
 // handleRequest is a handler used for all http monitoring requests
@@ -136,18 +135,9 @@ func (s *JSONStats) DecTXSignaling(t ptp.MessageType) {
 	s.txSignaling.dec(int(t))
 }
 
-// SetMaxWorkerLoad atomically sets worker load
-func (s *JSONStats) SetMaxWorkerLoad(workerid int, load int64) {
-	if load > s.workerLoad.load(workerid) {
-		s.workerLoad.store(workerid, load)
-	}
-}
-
-// SetMaxWorkerQueue atomically sets worker queue len
-func (s *JSONStats) SetMaxWorkerQueue(workerid int, queue int64) {
-	if queue > s.workerQueue.load(workerid) {
-		s.workerQueue.store(workerid, queue)
-	}
+// SetWorkerQueue atomically sets worker queue len
+func (s *JSONStats) SetWorkerQueue(queue int64) {
+	atomic.StoreInt64(&s.workerQueue, queue)
 }
 
 // SetMaxTXTSAttempts atomically sets number of retries for get latest TX timestamp

--- a/ptp4u/stats/json_test.go
+++ b/ptp4u/stats/json_test.go
@@ -31,19 +31,15 @@ func TestJSONStatsReset(t *testing.T) {
 	stats := JSONStats{}
 	stats.subscriptions.init()
 	stats.rxSignaling.init()
-	stats.workerLoad.init()
-	stats.workerQueue.init()
 
 	stats.IncSubscription(ptp.MessageAnnounce)
 	stats.IncRXSignaling(ptp.MessageSync)
-	stats.SetMaxWorkerLoad(10, 42)
-	stats.SetMaxWorkerQueue(10, 42)
+	stats.SetWorkerQueue(42)
 
 	stats.Reset()
 	require.Equal(t, int64(0), stats.subscriptions.load(int(ptp.MessageAnnounce)))
 	require.Equal(t, int64(0), stats.rxSignaling.load(int(ptp.MessageSync)))
-	require.Equal(t, int64(0), stats.workerLoad.load(10))
-	require.Equal(t, int64(0), stats.workerQueue.load(10))
+	require.Equal(t, int64(0), stats.workerQueue)
 }
 
 func TestJSONStatsAnnounceSubscription(t *testing.T) {
@@ -106,18 +102,11 @@ func TestJSONStatsTXSignaling(t *testing.T) {
 	require.Equal(t, int64(0), stats.txSignaling.load(int(ptp.MessageSync)))
 }
 
-func TestJSONStatsSetMaxWorkerLoad(t *testing.T) {
+func TestJSONStatsSetWorkerQueue(t *testing.T) {
 	stats := NewJSONStats()
 
-	stats.SetMaxWorkerLoad(10, 42)
-	require.Equal(t, int64(42), stats.workerLoad.load(10))
-}
-
-func TestJSONStatsSetMaxWorkerQueue(t *testing.T) {
-	stats := NewJSONStats()
-
-	stats.SetMaxWorkerQueue(10, 42)
-	require.Equal(t, int64(42), stats.workerQueue.load(10))
+	stats.SetWorkerQueue(42)
+	require.Equal(t, int64(42), stats.workerQueue)
 }
 
 func TestJSONStatsSetMaxTXTSAttempts(t *testing.T) {
@@ -176,6 +165,7 @@ func TestJSONExport(t *testing.T) {
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.SetUTCOffset(1)
+	stats.SetWorkerQueue(10)
 
 	stats.Snapshot()
 
@@ -195,6 +185,7 @@ func TestJSONExport(t *testing.T) {
 	expectedMap["tx.sync"] = 2
 	expectedMap["rx.signaling.delay_resp"] = 3
 	expectedMap["utcoffset"] = 1
+	expectedMap["worker.queue"] = 10
 
 	require.Equal(t, expectedMap, data)
 }

--- a/ptp4u/stats/stats.go
+++ b/ptp4u/stats/stats.go
@@ -71,11 +71,8 @@ type Stats interface {
 	// DecTXSignaling atomically removes 1 from the counter
 	DecTXSignaling(t ptp.MessageType)
 
-	// SetMaxWorkerLoad atomically sets worker load
-	SetMaxWorkerLoad(workerid int, load int64)
-
-	// SetMaxWorkerQueue atomically sets worker queue len
-	SetMaxWorkerQueue(workerid int, queue int64)
+	// SetWorkerQueue atomically sets worker queue len
+	SetWorkerQueue(queue int64)
 
 	// SetMaxTXTSAttempts atomically sets number of retries for get latest TX timestamp
 	SetMaxTXTSAttempts(workerid int, retries int64)
@@ -158,8 +155,7 @@ type counters struct {
 	tx            syncMapInt64
 	txSignaling   syncMapInt64
 	txtsattempts  syncMapInt64
-	workerLoad    syncMapInt64
-	workerQueue   syncMapInt64
+	workerQueue   int64
 	utcoffset     int64
 }
 
@@ -169,8 +165,6 @@ func (c *counters) init() {
 	c.tx.init()
 	c.rxSignaling.init()
 	c.txSignaling.init()
-	c.workerLoad.init()
-	c.workerQueue.init()
 	c.txtsattempts.init()
 }
 
@@ -180,10 +174,9 @@ func (c *counters) reset() {
 	c.tx.reset()
 	c.rxSignaling.reset()
 	c.txSignaling.reset()
-	c.workerLoad.reset()
-	c.workerQueue.reset()
 	c.txtsattempts.reset()
 	c.utcoffset = 0
+	c.workerQueue = 0
 }
 
 // toMap converts counters to a map
@@ -220,22 +213,13 @@ func (c *counters) toMap() (export map[string]int64) {
 		res[fmt.Sprintf("tx.signaling.%s", mt)] = c
 	}
 
-	for _, t := range c.workerLoad.keys() {
-		c := c.workerLoad.load(t)
-		res[fmt.Sprintf("worker.%d.load", t)] = c
-	}
-
-	for _, t := range c.workerQueue.keys() {
-		c := c.workerQueue.load(t)
-		res[fmt.Sprintf("worker.%d.queue", t)] = c
-	}
-
 	for _, t := range c.txtsattempts.keys() {
 		c := c.txtsattempts.load(t)
 		res[fmt.Sprintf("worker.%d.txtsattempts", t)] = c
 	}
 
 	res["utcoffset"] = c.utcoffset
+	res["worker.queue"] = c.workerQueue
 
 	return res
 }

--- a/ptp4u/stats/stats_test.go
+++ b/ptp4u/stats/stats_test.go
@@ -69,8 +69,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	c.tx.store(1, 1)
 	c.rxSignaling.store(1, 1)
 	c.txSignaling.store(1, 1)
-	c.workerLoad.store(1, 1)
-	c.workerQueue.store(1, 1)
+	c.workerQueue = 1
 	c.txtsattempts.store(1, 1)
 	c.utcoffset = 1
 
@@ -79,8 +78,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(1), c.tx.load(1))
 	require.Equal(t, int64(1), c.rxSignaling.load(1))
 	require.Equal(t, int64(1), c.txSignaling.load(1))
-	require.Equal(t, int64(1), c.workerLoad.load(1))
-	require.Equal(t, int64(1), c.workerQueue.load(1))
+	require.Equal(t, int64(1), c.workerQueue)
 	require.Equal(t, int64(1), c.txtsattempts.load(1))
 	require.Equal(t, int64(1), c.utcoffset)
 
@@ -91,8 +89,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(0), c.tx.load(1))
 	require.Equal(t, int64(0), c.rxSignaling.load(1))
 	require.Equal(t, int64(0), c.txSignaling.load(1))
-	require.Equal(t, int64(0), c.workerLoad.load(1))
-	require.Equal(t, int64(0), c.workerQueue.load(1))
+	require.Equal(t, int64(0), c.workerQueue)
 	require.Equal(t, int64(0), c.txtsattempts.load(1))
 	require.Equal(t, int64(0), c.utcoffset)
 }
@@ -113,6 +110,7 @@ func TestCountersToMap(t *testing.T) {
 	expectedMap["tx.sync"] = 2
 	expectedMap["rx.signaling.delay_resp"] = 3
 	expectedMap["utcoffset"] = 1
+	expectedMap["worker.queue"] = 0
 
 	require.Equal(t, expectedMap, result)
 }

--- a/simpleclient/client.go
+++ b/simpleclient/client.go
@@ -75,7 +75,12 @@ func (c *udpConnTS) WriteToWithTS(b []byte, addr net.Addr) (int, time.Time, erro
 	if err != nil {
 		return 0, time.Time{}, err
 	}
-	hwts, _, err := ptp.ReadTXtimestamp(c.UDPConn)
+	// get FD of the connection. Can be optimized by doing this when connection is created
+	connFd, err := ptp.ConnFd(c.UDPConn)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("failed to get conn fd udp connection: %v", err)
+	}
+	hwts, _, err := ptp.ReadTXtimestamp(connFd)
 	if err != nil {
 		return 0, time.Time{}, fmt.Errorf("failed to get timestamp of last packet: %v", err)
 	}


### PR DESCRIPTION
## Summary

* bump go to 1.16
* **protocol**: Provide allocation-free `BytesTo` function in ptp protocol that writes packet in binary form to provided io.Writer
* **protocol**: Expose `ConnFd`, avoid getting connection descriptor on every call of `ReadTXtimestamp`
* **protocol**: Versions of `ReadTXtimestamp` and `ReadPacketWithRXTimestamp` that allow providing buffers that could be later reused
* **ptp4u**: fixed leaking Timers in SubscriptionClient, simpler approach to expiration
* **ptp4u**: switched to reusable buffers and `BytesTo` + `ReadTXtimestampBuf` to avoid allocations when sending out packets
* **ptp4u**: cache of packet structs in sendWorkers
* **ptp4u**: single queue for sendWorkers
* **ptp4u**: stats updates for single queue

## Test Plan

Unittests work, extensive internal testing of ptp4u under heavy load shows big improvements, observed `runtime.MemStats.NextGC` value is now around 20% of what it was before.