### PR TITLE
Zero-allocation Marshalling and Unmarshalling in hot paths of protocol

### DIFF
--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package protocol
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,50 @@ func Test_parseSync(t *testing.T) {
 			OriginTimestamp: Timestamp{
 				Seconds:     [6]byte{0x0, 0x00, 0x45, 0xb1, 0x11, 0x5a},
 				Nanoseconds: 174389936,
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+
+	// test generic DecodePacket as well
+	pp, err := DecodePacket(raw)
+	require.Nil(t, err)
+	assert.Equal(t, &want, pp)
+}
+
+func Test_parseFollowup(t *testing.T) {
+	raw := []uint8{
+		0x8, 0x2, 0x0, 0x2c, 0x0, 0x0, 0x4, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x80, 0x63, 0xff, 0xff, 0x0,
+		0x9, 0xba, 0x0, 0x1, 0x0, 0x0, 0x2, 0x0, 0x0,
+		0x0, 0x45, 0xb1, 0x11, 0x5e, 0x4, 0x5d, 0xd2, 0x6e, 0x0, 0x0,
+	}
+	packet := new(FollowUp)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := FollowUp{
+		Header: Header{
+			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageFollowUp, 0),
+			Version:         Version,
+			MessageLength:   uint16(binary.Size(FollowUp{})),
+			DomainNumber:    0,
+			FlagField:       FlagUnicast,
+			SequenceID:      0,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 36138748164966842,
+			},
+			LogMessageInterval: 0,
+			ControlField:       2,
+		},
+		FollowUpBody: FollowUpBody{
+			PreciseOriginTimestamp: Timestamp{
+				Seconds:     [6]byte{0x0, 0x00, 0x45, 0xb1, 0x11, 0x5e},
+				Nanoseconds: 73257582,
 			},
 		},
 	}
@@ -118,4 +163,187 @@ func Test_parsePDelayReq(t *testing.T) {
 	pp, err := DecodePacket(raw)
 	require.Nil(t, err)
 	assert.Equal(t, &want, pp)
+}
+
+func Test_parseAnnounce(t *testing.T) {
+	raw := []uint8{
+		0xb, 0x2, 0x0, 0x40, 0x0, 0x0, 0x4, 0x8, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x80, 0x63, 0xff, 0xff, 0x0,
+		0x9, 0xba, 0x0, 0x1, 0x0, 0x0, 0x5, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x80, 0x6, 0x21, 0x59, 0xe0,
+		0x80, 0x0, 0x80, 0x63, 0xff, 0xff, 0x0,
+		0x9, 0xba, 0x0, 0x0, 0x20, 0x0, 0x0,
+	}
+	packet := new(Announce)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := Announce{
+		Header: Header{
+			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageAnnounce, 0),
+			Version:         Version,
+			MessageLength:   uint16(binary.Size(Announce{})),
+			DomainNumber:    0,
+			FlagField:       FlagUnicast | FlagPTPTimescale,
+			SequenceID:      0,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 36138748164966842,
+			},
+			LogMessageInterval: 0,
+			ControlField:       5,
+		},
+		AnnounceBody: AnnounceBody{
+			CurrentUTCOffset:     0,
+			Reserved:             0,
+			GrandmasterPriority1: 128,
+			GrandmasterClockQuality: ClockQuality{
+				ClockClass:              6,
+				ClockAccuracy:           33, // 0x21 - Time Accurate within 100ns
+				OffsetScaledLogVariance: 23008,
+			},
+			GrandmasterPriority2: 128,
+			GrandmasterIdentity:  36138748164966842,
+			StepsRemoved:         0,
+			TimeSource:           TimeSourceGNSS,
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+
+	// test generic DecodePacket as well
+	pp, err := DecodePacket(raw)
+	require.Nil(t, err)
+	assert.Equal(t, &want, pp)
+}
+
+func Test_parseDelayResp(t *testing.T) {
+	raw := []uint8{
+		0x9, 0x2, 0x0, 0x36, 0x0, 0x0, 0x4, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x80, 0x63, 0xff, 0xff, 0x0,
+		0x9, 0xba, 0x0, 0x1, 0x0, 0xa, 0x3, 0x7f,
+		0x0, 0x0, 0x45, 0xb1, 0x11, 0x5e, 0x4, 0x5d,
+		0xd2, 0x6e, 0xb8, 0x59, 0x9f, 0xff, 0xfe,
+		0x55, 0xaf, 0x4e, 0x0, 0x1, 0x0, 0x0,
+	}
+	packet := new(DelayResp)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := DelayResp{
+		Header: Header{
+			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageDelayResp, 0),
+			Version:         Version,
+			MessageLength:   uint16(binary.Size(DelayResp{})),
+			DomainNumber:    0,
+			FlagField:       FlagUnicast,
+			SequenceID:      10,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 36138748164966842,
+			},
+			LogMessageInterval: 0x7f,
+			ControlField:       3,
+			CorrectionField:    0,
+		},
+		DelayRespBody: DelayRespBody{
+			ReceiveTimestamp: Timestamp{
+				Seconds:     [6]byte{0x0, 0x00, 0x45, 0xb1, 0x11, 0x5e},
+				Nanoseconds: 73257582,
+			},
+			RequestingPortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 13283824497738493774,
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+
+	// test generic DecodePacket as well
+	pp, err := DecodePacket(raw)
+	require.Nil(t, err)
+	assert.Equal(t, &want, pp)
+}
+
+func BenchmarkReadSyncDelay(b *testing.B) {
+	raw := []uint8{
+		0x12, 0x02, 0x00, 0x36, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x63, 0xff,
+		0xff, 0x00, 0x09, 0xba, 0x00, 0x01, 0x9e, 0x57,
+		0x05, 0x0f, 0x00, 0x00, 0x45, 0xb1, 0x11, 0x5e,
+		0x04, 0x5d, 0xd2, 0x6e, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	p := &SyncDelayReq{}
+	for n := 0; n < b.N; n++ {
+		_ = p.UnmarshalBinary(raw)
+	}
+}
+
+func BenchmarkWriteSync(b *testing.B) {
+	p := &SyncDelayReq{
+		Header: Header{
+			SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageSync, 1),
+			Version:             2,
+			MessageLength:       44,
+			DomainNumber:        0,
+			MinorSdoID:          0,
+			FlagField:           0,
+			CorrectionField:     0,
+			MessageTypeSpecific: 0,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 36138748164966842,
+			},
+			SequenceID:         116,
+			ControlField:       0,
+			LogMessageInterval: 0,
+		},
+		SyncDelayReqBody: SyncDelayReqBody{
+			OriginTimestamp: Timestamp{
+				Seconds:     [6]byte{0x0, 0x00, 0x45, 0xb1, 0x11, 0x5a},
+				Nanoseconds: 174389936,
+			},
+		},
+	}
+	buf := make([]byte, 64)
+	for n := 0; n < b.N; n++ {
+		_, _ = BytesTo(p, buf)
+	}
+}
+
+func BenchmarkWriteFollowup(b *testing.B) {
+	p := &FollowUp{
+		Header: Header{
+			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageFollowUp, 0),
+			Version:         Version,
+			MessageLength:   uint16(binary.Size(FollowUp{})),
+			DomainNumber:    0,
+			FlagField:       FlagUnicast,
+			SequenceID:      0,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 36138748164966842,
+			},
+			LogMessageInterval: 0,
+			ControlField:       2,
+		},
+		FollowUpBody: FollowUpBody{
+			PreciseOriginTimestamp: Timestamp{
+				Seconds:     [6]byte{0x0, 0x00, 0x45, 0xb1, 0x11, 0x5e},
+				Nanoseconds: 73257582,
+			},
+		},
+	}
+	buf := make([]byte, 64)
+	for n := 0; n < b.N; n++ {
+		_, _ = BytesTo(p, buf)
+	}
 }

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -78,12 +78,10 @@ func NewSdoIDAndMsgType(msgType MessageType, sdoID uint8) SdoIDAndMsgType {
 
 // ProbeMsgType reads first 8 bits of data and tries to decode it to SdoIDAndMsgType, then return MessageType
 func ProbeMsgType(data []byte) (msg MessageType, err error) {
-	r := bytes.NewReader(data)
-	var sdoIDAndMsgType SdoIDAndMsgType
-	if err := binary.Read(r, binary.BigEndian, &sdoIDAndMsgType); err != nil {
-		return msg, err
+	if len(data) < 1 {
+		return 0, fmt.Errorf("not enough data to probe MsgType")
 	}
-	return sdoIDAndMsgType.MsgType(), nil
+	return SdoIDAndMsgType(data[0]).MsgType(), nil
 }
 
 // TLVType is type for TLV types
@@ -94,6 +92,8 @@ type TLV interface {
 	Type() TLVType
 }
 
+const tlvHeadSize = 4
+
 // TLVHead is a common part of all TLVs
 type TLVHead struct {
 	TLVType     TLVType
@@ -103,6 +103,11 @@ type TLVHead struct {
 // Type implements TLV interface
 func (t TLVHead) Type() TLVType {
 	return t.TLVType
+}
+
+func tlvHeadMarshalBinaryTo(t *TLVHead, b []byte) {
+	binary.BigEndian.PutUint16(b, uint16(t.TLVType))
+	binary.BigEndian.PutUint16(b[2:], t.LengthField)
 }
 
 // As per Table 52 tlvType values


### PR DESCRIPTION
Ditch `binary.Write/Read` in favour of manual reading/writing.

## Summary

Wrote benchmarks, they show that using `binary.Write/Read` is quite inefficient (allocations, reflection), so we have to do the dirty work ourselves.

## Test Plan
unittests, benchmarks:
```
BenchmarkReadSyncDelay-24       62649116                18.37 ns/op            0 B/op          0 allocs/op
BenchmarkWriteSync-24           47009586                26.03 ns/op            0 B/op          0 allocs/op
BenchmarkWriteFollowup-24       47982136                25.58 ns/op            0 B/op          0 allocs/op
BenchmarkWriteSignaling-24      20271586                49.71 ns/op            0 B/op          0 allocs/op
BenchmarkReadSignaling-24        4867161               210.9 ns/op           103 B/op          1 allocs/op
```