### PR TITLE
Improve allocations by switching to socketaddr

### DIFF
--- a/protocol/timestamp.go
+++ b/protocol/timestamp.go
@@ -95,13 +95,7 @@ func ioctlTimestamp(fd int, ifname string) error {
 }
 
 // EnableHWTimestampsSocket enables HW timestamps on the socket
-func EnableHWTimestampsSocket(conn *net.UDPConn, iface string) error {
-	// Get socket fd
-	connFd, err := ConnFd(conn)
-	if err != nil {
-		return err
-	}
-
+func EnableHWTimestampsSocket(connFd int, iface string) error {
 	if err := ioctlTimestamp(connFd, iface); err != nil {
 		return err
 	}
@@ -123,13 +117,7 @@ func EnableHWTimestampsSocket(conn *net.UDPConn, iface string) error {
 }
 
 // EnableSWTimestampsSocket enables SW timestamps on the socket
-func EnableSWTimestampsSocket(conn *net.UDPConn) error {
-	// Get socket fd
-	connFd, err := ConnFd(conn)
-	if err != nil {
-		return err
-	}
-
+func EnableSWTimestampsSocket(connFd int) error {
 	flags := unix.SOF_TIMESTAMPING_TX_SOFTWARE |
 		unix.SOF_TIMESTAMPING_RX_SOFTWARE |
 		unix.SOF_TIMESTAMPING_SOFTWARE |

--- a/protocol/timestamp_test.go
+++ b/protocol/timestamp_test.go
@@ -52,7 +52,7 @@ func Test_ReadTXtimestamp(t *testing.T) {
 	require.Equal(t, maxTXTS, attempts)
 	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", maxTXTS), err)
 
-	err = EnableSWTimestampsSocket(conn)
+	err = EnableSWTimestampsSocket(connFd)
 	require.Nil(t, err)
 
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}

--- a/ptp4u/server/server_test.go
+++ b/ptp4u/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	ptp "github.com/facebookincubator/ptp/protocol"
 	"github.com/facebookincubator/ptp/ptp4u/stats"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // Testing conversion so if Packet structure changes we notice
@@ -78,14 +79,15 @@ func TestServerRegisterSubscription(t *testing.T) {
 	require.Nil(t, scE)
 
 	// Add Sync. Check we got
-	scS = NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now())
+	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	scS = NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageSync, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageSync, scS)
 	// Check Sync is saved
 	scT = s.findSubscription(pi, ptp.MessageSync)
 	require.Equal(t, scS, scT)
 
 	// Add announce. Check we have now both
-	scA = NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now())
+	scA = NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageAnnounce, scA)
 	// First check Sync
 	scT = s.findSubscription(pi, ptp.MessageSync)
@@ -95,7 +97,7 @@ func TestServerRegisterSubscription(t *testing.T) {
 	require.Equal(t, scA, scT)
 
 	// Override announce
-	scA = NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now())
+	scA = NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageAnnounce, scA)
 	// Check new Announce is saved
 	scT = s.findSubscription(pi, ptp.MessageAnnounce)
@@ -120,19 +122,20 @@ func TestServerInventoryClients(t *testing.T) {
 	s := Server{Config: c, Stats: st}
 	s.clients.init()
 
-	scS1 := NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
+	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	scS1 := NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi1, ptp.MessageSync, scS1)
 	scS1.running = true
 	s.inventoryClients()
 	require.Equal(t, 1, len(s.clients.keys()))
 
-	scA1 := NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Now().Add(time.Minute))
+	scA1 := NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi1, ptp.MessageSync, scA1)
 	scA1.running = true
 	s.inventoryClients()
 	require.Equal(t, 1, len(s.clients.keys()))
 
-	scS2 := NewSubscriptionClient(&sendWorker{}, net.ParseIP("127.0.0.1"), ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
+	scS2 := NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi2, ptp.MessageSync, scS2)
 	scS2.running = true
 	s.inventoryClients()
@@ -175,4 +178,43 @@ func TestDelayRespPacket(t *testing.T) {
 	require.Equal(t, sp, dResp.Header.SourcePortIdentity)
 	require.Equal(t, now.Unix(), dResp.DelayRespBody.ReceiveTimestamp.Time().Unix())
 	require.Equal(t, ptp.FlagUnicast, dResp.Header.FlagField)
+}
+
+func TestIpToSockaddr(t *testing.T) {
+	ip4 := net.ParseIP("127.0.0.1")
+	ip6 := net.ParseIP("::1")
+	port := 123
+
+	expectedSA4 := &unix.SockaddrInet4{Port: port}
+	copy(expectedSA4.Addr[:], ip4.To4())
+
+	expectedSA6 := &unix.SockaddrInet6{Port: port}
+	copy(expectedSA6.Addr[:], ip6.To16())
+
+	sa4 := ipToSockaddr(ip4, port)
+	sa6 := ipToSockaddr(ip6, port)
+
+	require.Equal(t, expectedSA4, sa4)
+	require.Equal(t, expectedSA6, sa6)
+}
+
+func TestLoadOrStore(t *testing.T) {
+	ip4 := net.ParseIP("127.0.0.1")
+	ip6 := net.ParseIP("::1")
+	port := 123
+	expected4 := ipToSockaddr(ip4, port)
+	expected6 := ipToSockaddr(ip6, port)
+	s := syncMapSock{}
+	s.init()
+
+	require.Equal(t, 0, len(s.m))
+	// Store 2 and load 1
+	val4 := s.loadOrStore(ip4, 123)
+	val6 := s.loadOrStore(ip6, 123)
+	val6Load := s.loadOrStore(ip6, 123)
+
+	require.Equal(t, 2, len(s.m))
+	require.Equal(t, expected4, val4)
+	require.Equal(t, expected6, val6)
+	require.Equal(t, expected6, val6Load)
 }

--- a/ptp4u/server/subscription_test.go
+++ b/ptp4u/server/subscription_test.go
@@ -40,7 +40,8 @@ func TestSubscriptionStart(t *testing.T) {
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 1 * time.Minute
 	expire := time.Now().Add(1 * time.Second)
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
+	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start()
 	time.Sleep(100 * time.Millisecond)
@@ -54,7 +55,8 @@ func TestSubscriptionStop(t *testing.T) {
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 10 * time.Millisecond
 	expire := time.Now().Add(1 * time.Second)
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
+	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start()
 	time.Sleep(100 * time.Millisecond)
@@ -67,7 +69,8 @@ func TestSubscriptionStop(t *testing.T) {
 func TestSubscriptionflags(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 
 	require.Equal(t, ptp.FlagUnicast|ptp.FlagTwoStep, sc.syncPacket().Header.FlagField)
 	require.Equal(t, ptp.FlagUnicast, sc.followupPacket(time.Now()).Header.FlagField)

--- a/ptp4u/server/worker_test.go
+++ b/ptp4u/server/worker_test.go
@@ -48,7 +48,8 @@ func TestWorkerQueue(t *testing.T) {
 
 	interval := time.Millisecond
 	expire := time.Now().Add(time.Millisecond)
-	sc := NewSubscriptionClient(w, net.ParseIP("127.0.0.1"), ptp.MessageAnnounce, c, interval, expire)
+	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	for i := 0; i < 10; i++ {
 		w.queue <- sc

--- a/simpleclient/client.go
+++ b/simpleclient/client.go
@@ -211,9 +211,15 @@ func (c *Client) setup(ctx context.Context, eg *errgroup.Group) error {
 		return err
 	}
 
+	// get FD of the connection. Can be optimized by doing this when connection is created
+	connFd, err := ptp.ConnFd(eventConn)
+	if err != nil {
+		return err
+	}
+
 	// we need to enable HW or SW timestamps on event port
-	if err := ptp.EnableHWTimestampsSocket(eventConn, c.cfg.Iface); err != nil {
-		if err := ptp.EnableSWTimestampsSocket(eventConn); err != nil {
+	if err := ptp.EnableHWTimestampsSocket(connFd, c.cfg.Iface); err != nil {
+		if err := ptp.EnableSWTimestampsSocket(connFd); err != nil {
 			return fmt.Errorf("failed to enable timestamps on port %d: %v", ptp.PortEvent, err)
 		}
 		log.Warningf("Failed to enable hardware timestamps on port %d, falling back to software timestamps", ptp.PortEvent)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
UDP [WriteTo](https://github.com/golang/go/blob/658b5e66ecbc41a49e6fb5aa63c5d9c804cf305f/src/net/udpsock_posix.go#L79) is extremely inefficient. For every WriteTo it converts IP to the socket address with very many allocations.
```
$ go tool pprof -alloc_space ~/heap.out
File: ptp4u
Build ID: ddaae6815deb530f329ccdb36491b720
Type: alloc_space
Time: Jul 29, 2021 at 1:52pm (PDT)
Duration: 1mins, Total samples = 15.61GB
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 13252.52MB, 82.90% of 15985.72MB total
Dropped 22 nodes (cum <= 79.93MB)
Showing top 10 nodes out of 32
      flat  flat%   sum%        cum   cum%
 2229.77MB 13.95% 13.95%  4305.87MB 26.94%  github.com/facebookincubator/ptp/protocol.ReadPacketWithRXTimestamp
 1949.12MB 12.19% 26.14%  1949.12MB 12.19%  net.ipToSockaddr
 1932.21MB 12.09% 38.23%  1932.21MB 12.09%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
 1476.09MB  9.23% 47.46%  1476.09MB  9.23%  third-party-source/go/golang.org/x/sys/unix.ParseSocketControlMessage
 1362.10MB  8.52% 55.98%  1362.10MB  8.52%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).delayRespPacket
  992.61MB  6.21% 62.19%  1653.66MB 10.34%  github.com/facebookincubator/ptp/protocol.Bytes
  992.55MB  6.21% 68.40%  4410.83MB 27.59%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessage
  863.52MB  5.40% 73.80%  5983.40MB 37.43%  github.com/facebookincubator/ptp/ptp4u/server.(*sendWorker).Start
  822.54MB  5.15% 78.95%   822.54MB  5.15%  bytes.NewReader (inline)
  632.01MB  3.95% 82.90%   632.01MB  3.95%  github.com/facebookincubator/ptp/ptp4u/server.(*SubscriptionClient).Start
```
![Screenshot 2021-07-29 at 21 54 44](https://user-images.githubusercontent.com/4749052/127566193-209385fe-a619-49a1-b0f7-732331177bea.png)
On a large number of packets it's causing significant memory consumption and the GC pauses.
```
$ ps auxww | grep ptp4u
USER         PID %CPU %MEM    VSZ   RSS      TTY   STAT START   TIME COMMAND
root     4115829  468 27.5 23967348 18022984 pts/0 S<l+ 13:44 124:24 ptp4u -workers 100 -timestamptype hardware -loglevel error -pprofaddr [::]:8080
```

We can generate the socket address ourselves and therefore reduce large number of allocations.
```
$ go tool pprof -alloc_space ~/heap.out
File: ptp4u
Build ID: 0ac4757e6cea2ed3b590ded5e04e609e
Type: alloc_space
Time: Jul 29, 2021 at 1:42pm (PDT)
Duration: 1mins, Total samples = 12.03GB
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 10266.36MB, 83.33% of 12319.49MB total
Dropped 31 nodes (cum <= 61.60MB)
Showing top 10 nodes out of 30
      flat  flat%   sum%        cum   cum%
 2019.25MB 16.39% 16.39%  3962.34MB 32.16%  github.com/facebookincubator/ptp/protocol.ReadPacketWithRXTimestamp
 1789.19MB 14.52% 30.91%  1789.19MB 14.52%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
 1437.09MB 11.67% 42.58%  1437.09MB 11.67%  third-party-source/go/golang.org/x/sys/unix.ParseSocketControlMessage
 1248.10MB 10.13% 52.71%  1248.10MB 10.13%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).delayRespPacket
  905.10MB  7.35% 60.06%  1536.15MB 12.47%  github.com/facebookincubator/ptp/protocol.Bytes
  755.53MB  6.13% 66.19%   755.53MB  6.13%  bytes.NewReader (inline)
  539.51MB  4.38% 70.57%  4033.29MB 32.74%  github.com/facebookincubator/ptp/ptp4u/server.(*sendWorker).Start
  536.03MB  4.35% 74.92%   536.03MB  4.35%  syscall.anyToSockaddr
  530.03MB  4.30% 79.22%  3444.76MB 27.96%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessage
  506.53MB  4.11% 83.33%   506.53MB  4.11%  github.com/facebookincubator/ptp/protocol.(*DelayResp).MarshalBinary
```
![Screenshot 2021-07-29 at 21 44 58](https://user-images.githubusercontent.com/4749052/127566312-af4f8a00-42dc-4abc-8aaf-055ebfa028a5.png)


It's still not ideal but it's consuming at least 3-5 GiB less:
```
$ ps auxww | grep ptp4u
USER         PID %CPU %MEM    VSZ   RSS      TTY   STAT START   TIME COMMAND
root     4176080  451 22.4 18947620 14664200 pts/0 Sl+ 14:11  24:36 ./ptp4u -workers 100 -timestamptype hardware -loglevel error -pprofaddr [::]:8080
```