### PR TITLE
Use sockets instead of UDPConn for receive

### DIFF
--- a/protocol/timestamp_test.go
+++ b/protocol/timestamp_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // Testing conversion so if Packet structure changes we notice
@@ -114,4 +115,34 @@ func Test_scmDataToTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIPToSockaddr(t *testing.T) {
+	ip4 := net.ParseIP("127.0.0.1")
+	ip6 := net.ParseIP("::1")
+	port := 123
+
+	expectedSA4 := &unix.SockaddrInet4{Port: port}
+	copy(expectedSA4.Addr[:], ip4.To4())
+
+	expectedSA6 := &unix.SockaddrInet6{Port: port}
+	copy(expectedSA6.Addr[:], ip6.To16())
+
+	sa4 := IPToSockaddr(ip4, port)
+	sa6 := IPToSockaddr(ip6, port)
+
+	require.Equal(t, expectedSA4, sa4)
+	require.Equal(t, expectedSA6, sa6)
+}
+
+func TestSockaddrToIP(t *testing.T) {
+	ip4 := net.ParseIP("127.0.0.1")
+	ip6 := net.ParseIP("::1")
+	port := 123
+
+	sa4 := IPToSockaddr(ip4, port)
+	sa6 := IPToSockaddr(ip6, port)
+
+	require.Equal(t, ip4.String(), SockaddrToIP(sa4).String())
+	require.Equal(t, ip6.String(), SockaddrToIP(sa6).String())
 }

--- a/ptp4u/server/server_test.go
+++ b/ptp4u/server/server_test.go
@@ -24,7 +24,6 @@ import (
 	ptp "github.com/facebookincubator/ptp/protocol"
 	"github.com/facebookincubator/ptp/ptp4u/stats"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 )
 
 // Testing conversion so if Packet structure changes we notice
@@ -79,7 +78,7 @@ func TestServerRegisterSubscription(t *testing.T) {
 	require.Nil(t, scE)
 
 	// Add Sync. Check we got
-	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	scS = NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageSync, c, time.Second, time.Now())
 	s.registerSubscription(pi, ptp.MessageSync, scS)
 	// Check Sync is saved
@@ -122,7 +121,7 @@ func TestServerInventoryClients(t *testing.T) {
 	s := Server{Config: c, Stats: st}
 	s.clients.init()
 
-	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	scS1 := NewSubscriptionClient(&sendWorker{}, sa, sa, ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	s.registerSubscription(clipi1, ptp.MessageSync, scS1)
 	scS1.running = true
@@ -178,43 +177,4 @@ func TestDelayRespPacket(t *testing.T) {
 	require.Equal(t, sp, dResp.Header.SourcePortIdentity)
 	require.Equal(t, now.Unix(), dResp.DelayRespBody.ReceiveTimestamp.Time().Unix())
 	require.Equal(t, ptp.FlagUnicast, dResp.Header.FlagField)
-}
-
-func TestIpToSockaddr(t *testing.T) {
-	ip4 := net.ParseIP("127.0.0.1")
-	ip6 := net.ParseIP("::1")
-	port := 123
-
-	expectedSA4 := &unix.SockaddrInet4{Port: port}
-	copy(expectedSA4.Addr[:], ip4.To4())
-
-	expectedSA6 := &unix.SockaddrInet6{Port: port}
-	copy(expectedSA6.Addr[:], ip6.To16())
-
-	sa4 := ipToSockaddr(ip4, port)
-	sa6 := ipToSockaddr(ip6, port)
-
-	require.Equal(t, expectedSA4, sa4)
-	require.Equal(t, expectedSA6, sa6)
-}
-
-func TestLoadOrStore(t *testing.T) {
-	ip4 := net.ParseIP("127.0.0.1")
-	ip6 := net.ParseIP("::1")
-	port := 123
-	expected4 := ipToSockaddr(ip4, port)
-	expected6 := ipToSockaddr(ip6, port)
-	s := syncMapSock{}
-	s.init()
-
-	require.Equal(t, 0, len(s.m))
-	// Store 2 and load 1
-	val4 := s.loadOrStore(ip4, 123)
-	val6 := s.loadOrStore(ip6, 123)
-	val6Load := s.loadOrStore(ip6, 123)
-
-	require.Equal(t, 2, len(s.m))
-	require.Equal(t, expected4, val4)
-	require.Equal(t, expected6, val6)
-	require.Equal(t, expected6, val6Load)
 }

--- a/ptp4u/server/subscription.go
+++ b/ptp4u/server/subscription.go
@@ -83,8 +83,8 @@ func (sc *SubscriptionClient) Start() {
 	l := 10 * time.Second.Microseconds() / sc.interval.Microseconds()
 	atomic.AddInt64(&sc.worker.load, l)
 	defer atomic.AddInt64(&sc.worker.load, -l)
-	log.Infof("Starting a new %s subscription for %s", sc.subscriptionType, sc.eclisa)
-	log.Debugf("Starting a new %s subscription for %s with load %d with interval %s which expires in %s", sc.subscriptionType, sc.eclisa, l, sc.interval, sc.expire)
+	log.Infof("Starting a new %s subscription for %s", sc.subscriptionType, ptp.SockaddrToIP(sc.eclisa))
+	log.Debugf("Starting a new %s subscription for %s with load %d with interval %s which expires in %s", sc.subscriptionType, ptp.SockaddrToIP(sc.eclisa), l, sc.interval, sc.expire)
 
 	// Send first message right away
 	sc.worker.queue <- sc
@@ -94,12 +94,12 @@ func (sc *SubscriptionClient) Start() {
 
 	defer intervalTicker.Stop()
 	for range intervalTicker.C {
-		log.Debugf("Subscription %s for %s is valid until %s", sc.subscriptionType, sc.eclisa, sc.expire)
+		log.Debugf("Subscription %s for %s is valid until %s", sc.subscriptionType, ptp.SockaddrToIP(sc.eclisa), sc.expire)
 		if !sc.Running() {
 			return
 		}
 		if time.Now().After(sc.expire) {
-			log.Infof("Subscription %s is over for %s", sc.subscriptionType, sc.eclisa)
+			log.Infof("Subscription %s is over for %s", sc.subscriptionType, ptp.SockaddrToIP(sc.eclisa))
 			// TODO send cancellation
 			return
 		}

--- a/ptp4u/server/subscription_test.go
+++ b/ptp4u/server/subscription_test.go
@@ -40,7 +40,7 @@ func TestSubscriptionStart(t *testing.T) {
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 1 * time.Minute
 	expire := time.Now().Add(1 * time.Second)
-	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start()
@@ -55,7 +55,7 @@ func TestSubscriptionStop(t *testing.T) {
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 10 * time.Millisecond
 	expire := time.Now().Add(1 * time.Second)
-	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start()
@@ -69,7 +69,7 @@ func TestSubscriptionStop(t *testing.T) {
 func TestSubscriptionflags(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
-	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 
 	require.Equal(t, ptp.FlagUnicast|ptp.FlagTwoStep, sc.syncPacket().Header.FlagField)

--- a/ptp4u/server/worker.go
+++ b/ptp4u/server/worker.go
@@ -96,7 +96,7 @@ func (s *sendWorker) Start() {
 		copy(tbuf, emptyb)
 		copy(toob, emptyo)
 
-		log.Debugf("Processing client: %s", c.eclisa)
+		log.Debugf("Processing client: %s", ptp.SockaddrToIP(c.eclisa))
 
 		switch c.subscriptionType {
 		case ptp.MessageSync:
@@ -109,7 +109,7 @@ func (s *sendWorker) Start() {
 				continue
 			}
 			log.Debugf("Sending sync")
-			log.Tracef("Sending sync %+v to %s from %d", sync, c.eclisa, econn.LocalAddr().(*net.UDPAddr).Port)
+			log.Tracef("Sending sync %+v to %s from %d", sync, ptp.SockaddrToIP(c.eclisa), econn.LocalAddr().(*net.UDPAddr).Port)
 
 			err = unix.Sendto(eFd, buf[:n], 0, c.eclisa)
 			if err != nil {
@@ -137,7 +137,7 @@ func (s *sendWorker) Start() {
 				continue
 			}
 			log.Debugf("Sending followup")
-			log.Tracef("Sending followup %+v with ts: %s to %s from %d", followup, followup.FollowUpBody.PreciseOriginTimestamp.Time(), c.gclisa, gconn.LocalAddr().(*net.UDPAddr).Port)
+			log.Tracef("Sending followup %+v with ts: %s to %s from %d", followup, followup.FollowUpBody.PreciseOriginTimestamp.Time(), ptp.SockaddrToIP(c.gclisa), gconn.LocalAddr().(*net.UDPAddr).Port)
 
 			err = unix.Sendto(gFd, buf[:n], 0, c.gclisa)
 			if err != nil {
@@ -154,7 +154,7 @@ func (s *sendWorker) Start() {
 				continue
 			}
 			log.Debugf("Sending announce")
-			log.Tracef("Sending announce %+v to %s from %d", announce, c.gclisa, gconn.LocalAddr().(*net.UDPAddr).Port)
+			log.Tracef("Sending announce %+v to %s from %d", announce, ptp.SockaddrToIP(c.gclisa), gconn.LocalAddr().(*net.UDPAddr).Port)
 
 			err = unix.Sendto(gFd, buf[:n], 0, c.gclisa)
 			if err != nil {

--- a/ptp4u/server/worker_test.go
+++ b/ptp4u/server/worker_test.go
@@ -48,7 +48,7 @@ func TestWorkerQueue(t *testing.T) {
 
 	interval := time.Millisecond
 	expire := time.Now().Add(time.Millisecond)
-	sa := ipToSockaddr(net.ParseIP("127.0.0.1"), 123)
+	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	for i := 0; i < 10; i++ {

--- a/simpleclient/client.go
+++ b/simpleclient/client.go
@@ -262,13 +262,13 @@ func (c *Client) setup(ctx context.Context, eg *errgroup.Group) error {
 		doneChan := make(chan error, 1)
 		go func() {
 			for {
-				response, addr, rxtx, err := ptp.ReadPacketWithRXTimestamp(eventConn)
+				response, addr, rxtx, err := ptp.ReadPacketWithRXTimestamp(connFd)
 				if err != nil {
 					doneChan <- err
 					return
 				}
 				log.Debugf("got packet on port 319, addr = %v", addr)
-				if !addr.Equal(eventAddr.IP) {
+				if !ptp.SockaddrToIP(addr).Equal(eventAddr.IP) {
 					log.Warningf("ignoring packets from server %v", addr)
 				}
 				c.inChan <- &inPacket{data: response, ts: rxtx}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Use socket.Recvmsg everywhere. This allows us to avoid conversion to net.UDPConn which greatly reduces allocations and garbage delegations.
By using sockets everywhere it allows to simplify the code as well.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### Before
Notice the `UDPConn.ReadMsgUDP` ~0.87GiB and loadOrStore hack ~0.3GiB.
![image](https://user-images.githubusercontent.com/4749052/127740688-373c0abb-e204-48ef-a969-fa09f81eeda3.png)

### After
```
$ go tool pprof -alloc_space ~/heap.out
File: ptp4u
Build ID: 5670ad2fd454b86ca891ed96451e4d2d
Type: alloc_space
Time: Jul 31, 2021 at 5:33am (PDT)
Duration: 1.03mins, Total samples = 11.95GB
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 11610.01MB, 94.88% of 12236.12MB total
Dropped 13 nodes (cum <= 61.18MB)
Showing top 10 nodes out of 23
      flat  flat%   sum%        cum   cum%
 2916.81MB 23.84% 23.84%  3472.35MB 28.38%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
 2205.27MB 18.02% 41.86%  4166.43MB 34.05%  github.com/facebookincubator/ptp/protocol.ReadPacketWithRXTimestamp
 1532.59MB 12.53% 54.39%  1532.59MB 12.53%  third-party-source/go/golang.org/x/sys/unix.ParseSocketControlMessage
 1411.61MB 11.54% 65.92%  1411.61MB 11.54%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).delayRespPacket
  981.10MB  8.02% 73.94%  1628.16MB 13.31%  github.com/facebookincubator/ptp/protocol.Bytes
  575.51MB  4.70% 78.64%  3681.79MB 30.09%  github.com/facebookincubator/ptp/ptp4u/server.(*sendWorker).Start
  566.53MB  4.63% 83.27%  3500.78MB 28.61%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessage
  565.53MB  4.62% 87.90%   565.53MB  4.62%  third-party-source/go/golang.org/x/sys/unix.anyToSockaddr
  541.53MB  4.43% 92.32%   541.53MB  4.43%  github.com/facebookincubator/ptp/protocol.(*DelayResp).MarshalBinary
  313.51MB  2.56% 94.88%   313.51MB  2.56%  github.com/facebookincubator/ptp/ptp4u/server.(*SubscriptionClient).Start
```


![Screenshot 2021-07-31 at 13 35 37](https://user-images.githubusercontent.com/4749052/127740046-dced1a79-e2b8-4b77-8226-e1d049c20fdc.png)
