### PR TITLE
Tune control buffer size

### DIFF
--- a/protocol/timestamp.go
+++ b/protocol/timestamp.go
@@ -36,7 +36,7 @@ const (
 	// Control is a socket control message containing TX/RX timestamp
 	// If the read fails we may endup with multiple timestamps in the buffer
 	// which is best to read right away
-	ControlSizeBytes = 128
+	ControlSizeBytes = 64
 	// ptp packets usually up to 66 bytes
 	PayloadSizeBytes = 128
 	// look only for X sequential TS


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
ParseSocketControlMessage is a very costly operation performed on every TX/RX HWTS packet.
It's performed against entire control buffer so having 128 bytes literally demands 2x allocations on heap.
Although we are yet to figure out how to improve/replace ParseSocketControlMessage it's clear we can save a lot by just parsing only needed amount of control buffer.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
**(see the relative percentage, not the entire absolute values)**
### Before
```
$ go tool pprof -alloc_space ~/heap.out
File: ptp4u
Build ID: 574258b86ca02ad9c3fd94b4146fcb48
Type: alloc_space
Time: Aug 3, 2021 at 1:37pm (PDT)
Duration: 1mins, Total samples = 4.81GB
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 4.78GB, 99.31% of 4.81GB total
Dropped 34 nodes (cum <= 0.02GB)
Showing top 10 nodes out of 17
      flat  flat%   sum%        cum   cum%
    1.61GB 33.48% 33.48%     1.92GB 39.94%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
    1.09GB 22.60% 56.08%     2.85GB 59.22%  github.com/facebookincubator/ptp/ptp4u/server.(*sendWorker).Start
    0.86GB 17.95% 74.03%     0.86GB 17.95%  third-party-source/go/golang.org/x/sys/unix.ParseSocketControlMessage
    0.35GB  7.38% 81.41%     0.35GB  7.38%  github.com/facebookincubator/ptp/ptp4u/server.(*SubscriptionClient).Start
    0.32GB  6.57% 87.98%     0.32GB  6.57%  third-party-source/go/golang.org/x/sys/unix.anyToSockaddr
    0.31GB  6.41% 94.39%     0.31GB  6.41%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessage
    0.13GB  2.69% 97.08%     1.50GB 31.18%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).startEventListener.func1
    0.04GB  0.85% 97.93%     0.04GB  0.85%  github.com/facebookincubator/ptp/protocol.(*Signaling).MarshalBinary
    0.04GB  0.82% 98.76%     0.04GB  0.82%  github.com/facebookincubator/ptp/protocol.Timestamp.Time
    0.03GB  0.56% 99.31%     0.03GB  0.56%  github.com/facebookincubator/ptp/ptp4u/server.(*SubscriptionClient).grantPacket
```

### After
```
$ go tool pprof -alloc_space ~/heap.out_timestamp
File: ptp4u
Build ID: d2ea8ea5b6715e5fee055fb8388ba352
Type: alloc_space
Time: Aug 3, 2021 at 3:41pm (PDT)
Duration: 1mins, Total samples = 2.40GB
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 2.37GB, 98.77% of 2.40GB total
Dropped 5 nodes (cum <= 0.01GB)
Showing top 10 nodes out of 19
      flat  flat%   sum%        cum   cum%
    0.89GB 36.92% 36.92%     1.03GB 42.73%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
    0.60GB 25.04% 61.96%     1.40GB 58.40%  github.com/facebookincubator/ptp/ptp4u/server.(*sendWorker).Start
    0.23GB  9.37% 71.33%     0.23GB  9.37%  third-party-source/go/golang.org/x/sys/unix.ParseSocketControlMessage
    0.21GB  8.88% 80.21%     0.21GB  8.88%  github.com/facebookincubator/ptp/ptp4u/server.(*SubscriptionClient).Start
    0.15GB  6.08% 86.29%     0.15GB  6.08%  third-party-source/go/golang.org/x/sys/unix.anyToSockaddr
    0.14GB  5.79% 92.08%     0.14GB  5.79%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessage
    0.06GB  2.32% 94.40%     0.06GB  2.32%  github.com/facebookincubator/ptp/protocol.(*Signaling).MarshalBinary
    0.05GB  2.20% 96.59%     0.67GB 27.97%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).startEventListener.func1
    0.03GB  1.24% 97.83%     0.03GB  1.24%  github.com/facebookincubator/ptp/protocol.Timestamp.Time
    0.02GB  0.94% 98.77%     0.02GB  0.94%  github.com/facebookincubator/ptp/ptp4u/server.(*SubscriptionClient).grantPacket
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
