### PR TITLE
Slash 10% of allocations by hardcoding socket control message offset

### DIFF
--- a/protocol/timestamp_test.go
+++ b/protocol/timestamp_test.go
@@ -146,3 +146,19 @@ func TestSockaddrToIP(t *testing.T) {
 	require.Equal(t, ip4.String(), SockaddrToIP(sa4).String())
 	require.Equal(t, ip6.String(), SockaddrToIP(sa6).String())
 }
+
+/*
+o: [60 0 0 0 0 0 0 0 41 0 0 0 25 0 0 0 42 0 0 0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 64 0 0 0 0 0 0 0 1 0 0 0 65 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 230 180 10 97 0 0 0 0 239 83 199 39 0 0 0 0 ]
+Data [{Header:{Len:60 Level:41 Type:25} Data:[42 0 0 0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}, {Header:{Len:64 Level:1 Type:65} Data:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 230 180 10 97 0 0 0 0 239 83 199 39 0 0 0 0]}]
+*/
+func TestSocketControlMessageTimestamp(t *testing.T) {
+	if timestamping != unix.SO_TIMESTAMPING_NEW {
+		t.Skip("This test supports SO_TIMESTAMPING_NEW only. No sample of SO_TIMESTAMPING")
+	}
+
+	b := []byte{60, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 25, 0, 0, 0, 42, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 230, 180, 10, 97, 0, 0, 0, 0, 239, 83, 199, 39, 0, 0, 0, 0}
+	ts, err := socketControlMessageTimestamp(b)
+	require.NoError(t, err)
+	require.Equal(t, int64(1628091622667374575), ts.UnixNano())
+
+}


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Slash a large hot spot. The offset is constant on linux and project does not support other systems currently anyway.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### Before
![Screenshot 2021-08-04 at 16 19 13](https://user-images.githubusercontent.com/4749052/128207928-0339fc0e-d1ae-4f04-bf97-aa3188cf8c78.png)

### After
![Screenshot 2021-08-04 at 16 19 40](https://user-images.githubusercontent.com/4749052/128207947-540fdd0f-5117-4fad-b70d-9ea23fdc7b5c.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
