### PR TITLE
small fixes to timestamp.go and simpleclient after #17

### DIFF
--- a/protocol/timestamp.go
+++ b/protocol/timestamp.go
@@ -165,7 +165,8 @@ func socketControlMessageTimestamp(b []byte) (time.Time, error) {
 		h := (*unix.Cmsghdr)(unsafe.Pointer(&b[i]))
 		mlen = int(h.Len)
 
-		if h.Level == unix.SOL_SOCKET && int(h.Type) == timestamping {
+		// depending on the kernel version, when we ask for SO_TIMESTAMPING_NEW we still might get messages with type SO_TIMESTAMPING
+		if h.Level == unix.SOL_SOCKET && int(h.Type) == unix.SO_TIMESTAMPING_NEW || int(h.Type) == unix.SO_TIMESTAMPING {
 			return scmDataToTime(b[i+SocketControlMessageHeaderOffset : i+mlen])
 		}
 	}

--- a/ptpcheck/cmd/trace.go
+++ b/ptpcheck/cmd/trace.go
@@ -34,11 +34,13 @@ var traceRemoteServerFlag string
 var traceDurationFlag time.Duration
 var traceTimeoutFlag time.Duration
 var traceIfaceFlag string
+var traceTimestampingFlag string
 
 func init() {
 	RootCmd.AddCommand(traceCmd)
 	traceCmd.Flags().StringVarP(&traceRemoteServerFlag, "server", "S", "", "server to connect to")
 	traceCmd.Flags().StringVarP(&traceIfaceFlag, "iface", "i", "eth0", "network interface to use")
+	traceCmd.Flags().StringVarP(&traceTimestampingFlag, "timestamping", "T", "", fmt.Sprintf("timestamping to use, either %q or %q. empty means auto-detection", client.HWTIMESTAMP, client.SWTIMESTAMP))
 	traceCmd.Flags().DurationVarP(&traceTimeoutFlag, "timeout", "t", 15*time.Second, "global timeout")
 	traceCmd.Flags().DurationVarP(&traceDurationFlag, "duration", "d", 10*time.Second, "duration of the exchange")
 }
@@ -141,10 +143,11 @@ to notify about this event. Clients responds with ACKNOWLEDGE_CANCEL_UNICAST_TRA
 		}
 
 		cfg := &client.Config{
-			Address:  traceRemoteServerFlag,
-			Iface:    traceIfaceFlag,
-			Timeout:  traceTimeoutFlag,
-			Duration: traceDurationFlag,
+			Address:      traceRemoteServerFlag,
+			Iface:        traceIfaceFlag,
+			Timeout:      traceTimeoutFlag,
+			Duration:     traceDurationFlag,
+			Timestamping: traceTimestampingFlag,
 		}
 		if err := runTrace(cfg); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
## Summary

In #17 we introduced great optimization by using `unix.Recvmsg` instead of `ReadMsgUDP`, but it requires setting socket to blocking mode, which we forgot to do in `simpleclient`.

Also on older kernels we might end up with `SO_TIMESTAMPING` messages even when asked for `SO_TIMESTAMPING_NEW`.

And finally, ptpcheck now has `-T` flag to manually select timestamping mode.

## Test Plan

Local runs of `ptpcheck trace` in different modes