### PR TITLE
Add ziffy tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       tag: '1.16'
     steps:
       - checkout
+      - run: sudo apt-get install libpcap-dev
       - run: go get -v -t ./...
       - run: .circleci/linters.sh
   build:
@@ -23,6 +24,7 @@ jobs:
       tag: '1.16'
     steps:
       - checkout
+      - run: sudo apt-get install libpcap-dev
       - run: go get -v -t ./...
       - run: .circleci/build.sh
   tests:
@@ -32,6 +34,7 @@ jobs:
       tag: '1.16'
     steps:
       - checkout
+      - run: sudo apt-get install libpcap-dev
       - run: go get -v -t ./...
       - run: .circleci/tests.sh
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Simple tool to read pcap/pcapng captures and parse and print PTP packets from th
 Allows to test our protocol parser implementation against arbitrary tcpdump capture.
 Also the code shows integration with *GoPacket* library.
 
+## ziffy
+CLI tool to triangulate datacenter switches that are not operating correctly as PTP Transparent Clocks.
+
 ## ptpcheck
 CLI and library to perform various PTP-related tasks, including:
 * reporting stats taken from local PTP instance in JSON format

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/fatih/color v1.12.0
 	github.com/golang/mock v1.5.0
 	github.com/google/gopacket v1.1.19
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/vtolstov/go-ioctl v0.0.0-20151206205506-6be9cced4810
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1
 )

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -134,6 +136,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/ziffy/README.md
+++ b/ziffy/README.md
@@ -1,0 +1,32 @@
+# ziffy
+CLI tool to triangulate datacenter switches that are not operating correctly as PTP Transparent Clocks.
+
+### How to sweep the network topology?
+
+Ziffy sends PTP SYNC/DELAY\_REQ packets between two hosts, a Ziffy sender and a Ziffy receiver in order to get data about the topology. It supports sending packets from a range of source ports to encourage hashing of traffic over multiple paths. In case the hashing is done using only destination IP and source IP, Ziffy can target multiple IPs in the same /64 prefix as the destination.
+
+### How to determine if a switch is operating as PTP TC?
+
+In order to determine if a switch is a PTP Transparent Clock, Ziffy sends IPv6 PTP SYNC/DELAY\_REQ packets with the same (srcIP, srcPort, destIP, destPort) tuple but with consecutive Hop Limit. When a PTP packet is dropped by a switch, a ICMPv6 Hop limit exceeded packet containing the entire PTP packet is returned to the sender.
+
+Consider that `Switch3` was hit using `HopLimit=3` and `Switch4` was hit using `HopLimit=4`. If `(Switch4.CorrectionField - Switch3.CorrectionField < threshold)` then `Switch3` did not modify the `CorrectionField`, so it is not a Transparent Clock.
+
+## Run
+Run Ziffy in receiver mode on a host, and Ziffy in sender mode on another host.
+
+```
+sudo ziffy -mode receiver
+```
+```
+sudo ziffy -mode sender -addr <<receiver_hostname>> -maxhop 6 -portcount 80 -ipcount 5 -sp 31000
+```
+
+This will send 80 PTP SYNC packets to `<<receiver_hostname>>` from source port range 31000-31079 with max hop count of 6 and min hop count of 1, sweeping 5 more addresses in target network prefix. Total flows 480.
+
+## Requirements
+* IPv6
+* sudo - needed because
+    * ziffy listens for packets even if the port is already used by another process, using a BPF filter 
+    * ziffy decodes raw packets
+    * minimal capabilities to run ziffy: `cap_net_raw=eip`.
+* pcap library - used to build and run ziffy.

--- a/ziffy/main.go
+++ b/ziffy/main.go
@@ -1,0 +1,150 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+	"github.com/facebookincubator/ptp/ziffy/node"
+	log "github.com/sirupsen/logrus"
+)
+
+const doc = `
+Ziffy is a CLI tool intended to triangulate datacenter switches that are not operating correctly as PTP TCs.
+
+How to sweep the network topology?
+
+	Ziffy sends PTP SYNC/DELAY_REQ packets between two hosts, a Ziffy sender and a Ziffy receiver in order to
+	get data about the topology. It supports sending packets from a range of source ports to encourage hashing of
+	traffic over multiple paths. In case the hashing is done using only destination IP and source IP, Ziffy can
+	target multiple IPs in the same /64 prefix as the destination.
+
+How to determine if a switch is operating as PTP TC?
+
+	In order to determine if a switch is a PTP Transparent Clock, Ziffy sends IPV6 PTP SYNC/DELAY_REQ packets with
+	the same (srcIP, srcPort, destIP, destPort) tuple but with consecutive Hop Limit. When a PTP packet is dropped
+	by a switch, a ICMPv6 Hop limit exceeded packet containing the entire PTP packet is returned to the sender.
+
+	Consider that Switch3 was hit using HopLimit=3 and Switch4 was hit using HopLimit=4.
+	If (Switch4.CorrectionField - Switch3.CorrectionField < threshold) then Switch3 did not modify the CorrectionField,
+	so it is not a Transparent Clock.
+
+Flags:
+`
+
+func main() {
+	c := &node.Config{}
+
+	var messageType string
+	var nsCFThreshold int
+
+	flag.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), doc)
+		flag.PrintDefaults()
+	}
+
+	flag.StringVar(&c.LogLevel, "loglevel", "info", "set a log level. Can be: trace, debug, info, warning, error")
+	flag.StringVar(&c.Mode, "mode", "receiver", "set the mode. Can be either sender or receiver")
+	flag.StringVar(&c.Device, "if", "eth0", "network interface to use")
+	flag.IntVar(&c.HopMax, "maxhop", 7, "max number of hops (used by sender)")
+	flag.IntVar(&c.HopMin, "minhop", 1, "min number of hops (used by sender)")
+	flag.DurationVar(&c.IcmpTimeout, "icmptime", 1*time.Second, "max timeout to wait for icmp packets (used by sender)")
+	flag.StringVar(&c.DestinationAddress, "addr", "", "IP address of receiver (used by sender)")
+	flag.IntVar(&c.DestinationPort, "dp", ptp.PortEvent, "destination port to send packets to")
+	flag.IntVar(&c.SourcePort, "sp", 32768, "the base source port to start probing (used by sender)")
+	flag.IntVar(&c.PortCount, "portcount", 1, "port count to be used for probing each target ip (used by sender)")
+	flag.StringVar(&messageType, "type", "sync", "set the message type. Can be sync (default) or delay_req (used by sender)")
+	flag.StringVar(&c.CsvFile, "csv", "", "csv output file path (used by sender)")
+	flag.BoolVar(&c.ContReached, "continue", false, "continue incrementing hop count after destination host responds (used by sender)")
+	flag.IntVar(&c.IPCount, "ipcount", 0, "number of additional IPs targeted in the same /64 prefix as destination to increase hashing entropy (used by sender)")
+	flag.IntVar(&c.DSCP, "dscp", 0, "DSCP for PTP packets, valid values are between 0-63 (used by sender)")
+	flag.DurationVar(&c.LLDPWaitTime, "lldptime", 5*time.Second, "max timeout to wait for LLDP packets (used by sender)")
+	flag.IntVar(&c.QueueCap, "qcap", 10000, "ICMP queue capacity (used by sender)")
+	flag.DurationVar(&c.IcmpReplyTime, "replytime", 1*time.Second, "waiting time for late icmp packets (used by sender)")
+	flag.IntVar(&nsCFThreshold, "cfthreshold", 250, "CorrectionField threshold (CF difference < abs(CFThreshold) => switch not TC) (used by sender)")
+	flag.IntVar(&c.PTPRecvHandlers, "maxhandlers", 10000, "maximum number of simultaneous goroutines used to handle PTP packets (used by receiver)")
+
+	flag.Parse()
+
+	log.Debugf("\nLogLevel = %v\nMode = %v\nDestinationAddress = %v\nDestinationPort = %v\nSourcePort = %v\n",
+		c.LogLevel, c.Mode, c.DestinationAddress, c.DestinationPort, c.SourcePort)
+
+	if c.DSCP < 0 || c.DSCP > 63 {
+		log.Fatalf("unsupported DSCP value %v", c.DSCP)
+	}
+
+	if c.IcmpTimeout < 100*time.Millisecond {
+		log.Warnf("setting timeout < 100ms for ICMP replies may lead to inaccurate results")
+	}
+
+	switch messageType {
+	case "delay_req":
+		c.MessageType = ptp.MessageDelayReq
+	case "sync":
+		c.MessageType = ptp.MessageSync
+	default:
+		log.Fatalf("unsupported message type %q", messageType)
+	}
+
+	switch c.LogLevel {
+	case "trace":
+		log.SetLevel(log.TraceLevel)
+	case "debug":
+		log.SetLevel(log.DebugLevel)
+	case "info":
+		log.SetLevel(log.InfoLevel)
+	case "warning":
+		log.SetLevel(log.WarnLevel)
+	case "error":
+		log.SetLevel(log.ErrorLevel)
+	default:
+		log.Fatalf("unrecognized log level: %v", c.LogLevel)
+	}
+
+	switch c.Mode {
+	case "receiver":
+		log.Infof("RECEIVER")
+
+		r := node.Receiver{
+			Config: c,
+		}
+		if err := r.Start(); err != nil {
+			log.Errorf("receiver start failed: %v", err)
+		}
+	case "sender":
+		log.Infof("SENDER")
+
+		s := node.Sender{
+			Config: c,
+		}
+
+		info, err := s.Start()
+		if err != nil {
+			log.Errorf("sender start failed: %v", err)
+		}
+
+		node.PrettyPrint(info, ptp.NewCorrection(float64(nsCFThreshold)))
+		if s.Config.CsvFile != "" {
+			node.CsvPrint(info, s.Config.CsvFile, ptp.NewCorrection(float64(nsCFThreshold)))
+		}
+	default:
+		log.Errorf("--mode must be sender or receiver")
+	}
+}

--- a/ziffy/node/config.go
+++ b/ziffy/node/config.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"time"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+)
+
+const (
+	// ZiffyHexa signs zi(0xff)y PTP packets
+	ZiffyHexa = 0xff
+	// Ipv6HeaderSize is ipv6 header size
+	Ipv6HeaderSize = 40
+	// UDPHeaderSize is udp header size
+	UDPHeaderSize = 8
+	// ICMPHeaderSize is icmp ipv6 header size
+	ICMPHeaderSize = 8
+	// PTPUnusedSize received from sender
+	PTPUnusedSize = 10
+)
+
+// Config is the Ziffy config struct
+type Config struct {
+	Mode               string
+	LogLevel           string
+	Device             string
+	CsvFile            string
+	DestinationAddress string
+	DestinationPort    int
+	SourcePort         int
+	PortCount          int
+	HopMax             int
+	HopMin             int
+	IPCount            int
+	DSCP               int
+	PTPRecvHandlers    int
+	ContReached        bool
+	IcmpTimeout        time.Duration
+	MessageType        ptp.MessageType
+	LLDPWaitTime       time.Duration
+	IcmpReplyTime      time.Duration
+
+	// QueueCap used to store ICMP messages. Capacity is the number of late messages
+	// stored until the queue is cleared. After each traceRoute, sender clears the queue.
+	// For worst case scenario maximum capacity should be (HopMax - HopMin + 1) * PortCount * IPCount
+	QueueCap int
+}
+
+// SwitchPrintInfo contains print information for switches
+type SwitchPrintInfo struct {
+	ip        string
+	hostname  string
+	interf    string
+	routes    int
+	divRoutes int
+	totalCF   ptp.Correction
+	avgCF     ptp.Correction
+	maxCF     ptp.Correction
+	minCF     ptp.Correction
+	tcEnable  status
+	hop       int
+	last      bool
+}
+
+// SwitchTrafficInfo contains information about a switch
+type SwitchTrafficInfo struct {
+	ip        string
+	corrField ptp.Correction
+	routeIdx  int
+	hop       int
+}
+
+// PathInfo contains the list of switches in a path
+type PathInfo struct {
+	switches       []SwitchTrafficInfo
+	rackSwHostname string
+}

--- a/ziffy/node/print.go
+++ b/ziffy/node/print.go
@@ -1,0 +1,327 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/csv"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
+)
+
+type status int
+
+const (
+	tcTrue = iota
+	tcFalse
+	tcNA
+)
+
+var statusToString = map[status]string{
+	tcTrue:  "On",
+	tcFalse: "Off",
+	tcNA:    "Unknown",
+}
+
+const maxColWidth = 100
+
+type keyPair struct {
+	host string
+	hop  int
+}
+
+func min(x int, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+// getHostNoPrefix has ip as input and returns device hostname without interface prefix
+func getHostNoPrefix(ip string) string {
+	lun := getLookUpName(ip)
+	if strings.Contains(lun, ".") && lun[:3] == "eth" {
+		return lun[strings.Index(lun, ".")+1:]
+	}
+	return lun
+}
+
+// getHostIfPrefix has ip as input and returns device interface without suffix
+func getHostIfPrefix(ip string) string {
+	lun := getLookUpName(ip)
+	if strings.Contains(lun, ".") && lun[:3] == "eth" {
+		return lun[:strings.Index(lun, ".")]
+	}
+	return ""
+}
+
+// PrettyPrint formats and prints the output to stdout
+func PrettyPrint(routes []PathInfo, cfThreshold ptp.Correction) {
+	debugPrint(routes)
+	info := computeInfo(routes, cfThreshold)
+	detailedPrint(info)
+}
+
+func debugPrint(routes []PathInfo) {
+	var notTCEnabled []SwitchTrafficInfo
+	tested := make(map[string]bool)
+	enabled := 0
+
+	for _, route := range routes {
+		for swIndex, swh := range route.switches {
+			if swIndex == len(route.switches)-1 {
+				continue
+			}
+			corrField := route.switches[swIndex+1].corrField - route.switches[swIndex].corrField
+			if corrField == ptp.Correction(0) && !tested[swh.ip] {
+				notTCEnabled = append(notTCEnabled, swh)
+			}
+			tested[swh.ip] = true
+			enabled++
+		}
+	}
+
+	log.Debugf("%v switches tested: %v TC enabled | %v TC not enabled", len(tested), enabled, len(notTCEnabled))
+	for _, brkSw := range notTCEnabled {
+		log.Debugf("%v: PTP TC not enabled", getLookUpName(brkSw.ip))
+		for index, swh := range routes[brkSw.routeIdx].switches {
+			if index != len(routes[brkSw.routeIdx].switches)-1 {
+				log.Debugf(" | %v", getLookUpName(swh.ip))
+			} else {
+				log.Debugf(" V %v", getLookUpName(swh.ip))
+			}
+		}
+	}
+
+	log.Debugf("TESTED:")
+	var aux []string
+	for key := range tested {
+		aux = append(aux, getLookUpName(key))
+	}
+	sort.Slice(aux, func(i, j int) bool {
+		return aux[i] > aux[j]
+	})
+	for index, element := range aux {
+		log.Debugf("%v %v", index, element)
+	}
+}
+
+func computeInfo(routes []PathInfo, cfThreshold ptp.Correction) map[keyPair]*SwitchPrintInfo {
+	discovered := make(map[keyPair]*SwitchPrintInfo)
+
+	for _, route := range routes {
+		for swIndex, swh := range route.switches {
+			corrField := ptp.Correction(0)
+			last := false
+			host := getHostNoPrefix(swh.ip)
+			intf := getHostIfPrefix(swh.ip)
+
+			if swh.ip == route.switches[len(route.switches)-1].ip {
+				last = true
+			} else {
+				// If switches are not adjacent (hop count difference > 1) do not subtract CF
+				// This may happen in two cases: switch does not send ICMP Hop Limit Exceeded
+				// back to source or the packet may be lost in transit
+				if route.switches[swIndex+1].hop != route.switches[swIndex].hop+1 {
+					last = true
+				} else {
+					corrField = route.switches[swIndex+1].corrField - route.switches[swIndex].corrField
+				}
+			}
+
+			if swh.hop == 1 && route.rackSwHostname != "" {
+				host = route.rackSwHostname
+			}
+
+			pair := keyPair{
+				host: host,
+				hop:  int(swh.hop),
+			}
+			if discovered[pair] == nil {
+				discovered[pair] = &SwitchPrintInfo{
+					ip:        swh.ip,
+					hostname:  host,
+					interf:    intf,
+					totalCF:   corrField,
+					routes:    1,
+					hop:       int(swh.hop),
+					last:      last,
+					maxCF:     corrField,
+					minCF:     corrField,
+					divRoutes: 1,
+				}
+			} else {
+				discovered[pair].routes++
+				if !last {
+					discovered[pair].totalCF += corrField
+					discovered[pair].divRoutes++
+					if discovered[pair].maxCF < corrField {
+						discovered[pair].maxCF = corrField
+					}
+					if discovered[pair].minCF > corrField {
+						discovered[pair].minCF = corrField
+					}
+				}
+			}
+		}
+	}
+	for _, sw := range discovered {
+		if sw.last {
+			sw.avgCF = ptp.Correction(0)
+			sw.tcEnable = tcNA
+			continue
+		}
+		sw.avgCF = sw.totalCF / ptp.Correction(sw.divRoutes)
+
+		avgCFNs := sw.avgCF.Nanoseconds()
+		cfThresholdNs := cfThreshold.Nanoseconds()
+		if math.Abs(avgCFNs) > cfThresholdNs {
+			sw.tcEnable = tcTrue
+		} else {
+			sw.tcEnable = tcFalse
+		}
+	}
+	return discovered
+}
+
+func parseSwitchMap(info map[keyPair]*SwitchPrintInfo) []SwitchPrintInfo {
+	var aux []SwitchPrintInfo
+	for _, val := range info {
+		aux = append(aux, *val)
+	}
+	sort.Slice(aux, func(i, j int) bool {
+		return aux[i].hop < aux[j].hop
+	})
+	return aux
+}
+
+func hopCount(sw []SwitchPrintInfo, hop int) int {
+	width := 0
+	for _, val := range sw {
+		if val.hop == hop {
+			width++
+		}
+	}
+	return width
+}
+
+func colNumber(header []string, colName string) (int, error) {
+	for ind, val := range header {
+		if val == colName {
+			return ind, nil
+		}
+	}
+	return -1, fmt.Errorf("no column with this name")
+}
+
+func computePrintData(sw []SwitchPrintInfo) [][]string {
+	var ret [][]string
+	ret = append(ret, []string{"uniq", "width", "hop", "ip_address", "intf", "hostname", "flows", "TC", "avg_CF(ns)", "max_CF(ns)", "min_CF(ns)"})
+
+	// unique counts number of devices discovered
+	unique := 1
+	already := make(map[string]bool)
+
+	for _, val := range sw {
+		avgDisplay := strconv.FormatFloat(val.avgCF.Nanoseconds(), 'f', 4, 64)
+		minDisplay := strconv.FormatFloat(val.minCF.Nanoseconds(), 'f', 4, 64)
+		maxDisplay := strconv.FormatFloat(val.maxCF.Nanoseconds(), 'f', 4, 64)
+
+		uniqDisplay := ""
+		if val.last {
+			avgDisplay = ""
+			minDisplay = ""
+			maxDisplay = ""
+		}
+		if !already[val.hostname] {
+			uniqDisplay = strconv.Itoa(unique)
+			already[val.hostname] = true
+			unique++
+		}
+		ret = append(ret, []string{uniqDisplay, strconv.Itoa(hopCount(sw, val.hop)), strconv.Itoa(val.hop), val.ip, val.interf, val.hostname,
+			strconv.Itoa(val.routes), statusToString[val.tcEnable], avgDisplay, maxDisplay, minDisplay})
+	}
+	return ret
+}
+
+func detailedPrint(info map[keyPair]*SwitchPrintInfo) {
+	aux := parseSwitchMap(info)
+	data := computePrintData(aux)
+
+	// currentHop is incremented each time we pass to the next hop. Used to print newline between hops
+	currentHop := 0
+	// headerRow is the row index for the header
+	headerRow := 0
+	// blank space for data
+	blank := []string{"", "", "", "", "", "", "", "", "", "", ""}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetColWidth(maxColWidth)
+	table.SetHeader(data[headerRow])
+
+	for _, val := range data[headerRow+1:] {
+		hopInd, err := colNumber(data[headerRow], "hop")
+		if err != nil {
+			log.Errorf("detailedPrint failed: %v", err)
+			return
+		}
+
+		nextHop, err := strconv.Atoi(val[hopInd])
+		if err != nil {
+			log.Errorf("strconv atoi failed: %v", err)
+			return
+		}
+
+		if nextHop > currentHop {
+			table.Append(blank)
+		}
+		table.Append(val)
+
+		currentHop = nextHop
+	}
+	table.Render()
+}
+
+// CsvPrint outputs the data in a csv file
+func CsvPrint(routes []PathInfo, path string, cfThreshold ptp.Correction) {
+	info := computeInfo(routes, cfThreshold)
+	aux := parseSwitchMap(info)
+	data := computePrintData(aux)
+
+	file, err := os.Create(path)
+	if err != nil {
+		log.Errorf("unable to open file: %v", err)
+		return
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	for _, val := range data {
+		if err := writer.Write(val); err != nil {
+			log.Debugf("unable to write to file: %v", err)
+		}
+	}
+}

--- a/ziffy/node/print_test.go
+++ b/ziffy/node/print_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"strconv"
+	"testing"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMin(t *testing.T) {
+	require.Equal(t, 2, min(2, 3))
+	require.Equal(t, 2, min(2, 100))
+	require.Equal(t, -3, min(2, -3))
+	require.Equal(t, 1, min(1, 1))
+	require.Equal(t, -4, min(-2, -4))
+}
+
+func TestComputeInfo(t *testing.T) {
+	s := Sender{
+		Config: &Config{},
+	}
+	numInfos := 5
+	cfThold := 250
+	cfIncrement := 100
+	currentCf := 0
+
+	s.routes = append(s.routes, PathInfo{})
+
+	for i := 0; i <= numInfos; i++ {
+		s.routes[0].switches = append(s.routes[0].switches, SwitchTrafficInfo{
+			ip:        strconv.Itoa(i),
+			hop:       i,
+			corrField: ptp.NewCorrection(float64(currentCf)),
+		})
+		currentCf += cfIncrement
+	}
+
+	info := computeInfo(s.routes, ptp.NewCorrection(float64(cfThold)))
+
+	for i := 0; i <= numInfos; i++ {
+		if info[keyPair{strconv.Itoa(i), i}].last {
+			require.Equal(t, tcNA, int(info[keyPair{strconv.Itoa(i), i}].tcEnable))
+			continue
+		}
+		if info[keyPair{strconv.Itoa(i), i}].avgCF > ptp.NewCorrection(float64(cfThold)) {
+			require.Equal(t, tcTrue, int(info[keyPair{strconv.Itoa(i), i}].tcEnable))
+		} else {
+			require.Equal(t, tcFalse, int(info[keyPair{strconv.Itoa(i), i}].tcEnable))
+		}
+	}
+}
+
+func TestGetHostNoPrefix(t *testing.T) {
+	require.Equal(t, "localhost", getHostNoPrefix("eth1.localhost"))
+	require.Equal(t, "localhost", getHostNoPrefix("eth1-432.localhost"))
+	require.Equal(t, "sswyyy.asd.asd.asd.tfbnw.net.", getHostNoPrefix("eth4-4-1.sswyyy.asd.asd.asd.tfbnw.net."))
+	require.Equal(t, "sswyyy.asd.asd.asd.tfbnw.net.", getHostNoPrefix("sswyyy.asd.asd.asd.tfbnw.net."))
+	require.Equal(t, "2401:face:face::", getHostNoPrefix("2401:face:face::"))
+	require.Equal(t, "1.2.3.4", getHostNoPrefix("1.2.3.4"))
+	require.Equal(t, "1.2.3.4", getHostNoPrefix("eth0.1.2.3.4"))
+}
+
+func TestGetHostIfPrefix(t *testing.T) {
+	require.Equal(t, "eth1", getHostIfPrefix("eth1.localhost"))
+	require.Equal(t, "eth1-432", getHostIfPrefix("eth1-432.localhost"))
+	require.Equal(t, "eth4-4-1", getHostIfPrefix("eth4-4-1.sswyyy.asd.asd.asd.tfbnw.net."))
+	require.Equal(t, "", getHostIfPrefix("sswyyy.asd.asd.asd.tfbnw.net."))
+	require.Equal(t, "", getHostIfPrefix("2401:face:face::"))
+	require.Equal(t, "", getHostIfPrefix("1.2.3.4"))
+	require.Equal(t, "eth0", getHostIfPrefix("eth0.1.2.3.4"))
+}
+
+func TestHopCount(t *testing.T) {
+	swInfo := []SwitchPrintInfo{
+		SwitchPrintInfo{hop: 1},
+		SwitchPrintInfo{hop: 1},
+		SwitchPrintInfo{hop: 2},
+		SwitchPrintInfo{hop: 2},
+		SwitchPrintInfo{hop: 2},
+		SwitchPrintInfo{hop: 3},
+		SwitchPrintInfo{hop: 4},
+		SwitchPrintInfo{hop: 4},
+		SwitchPrintInfo{hop: 4},
+		SwitchPrintInfo{hop: 4},
+	}
+
+	cnt := hopCount(swInfo, 1)
+	require.Equal(t, 2, cnt)
+
+	cnt = hopCount(swInfo, 2)
+	require.Equal(t, 3, cnt)
+
+	cnt = hopCount(swInfo, 3)
+	require.Equal(t, 1, cnt)
+
+	cnt = hopCount(swInfo, 4)
+	require.Equal(t, 4, cnt)
+
+	cnt = hopCount(swInfo, 5)
+	require.Equal(t, 0, cnt)
+
+	cnt = hopCount(swInfo, -1)
+	require.Equal(t, 0, cnt)
+}
+
+func TestColNumber(t *testing.T) {
+	header := []string{"uniq", "width", "hop", "ip_address", "intf", "hostname", "flows", "TC", "avg_CF(ns)", "max_CF(ns)", "min_CF(ns)"}
+
+	nr, err := colNumber(header, "uniq")
+	require.Nil(t, err)
+	require.Equal(t, 0, nr)
+
+	nr, err = colNumber(header, "ip_address")
+	require.Nil(t, err)
+	require.Equal(t, 3, nr)
+
+	nr, err = colNumber(header, "avg_CF(ns)")
+	require.Nil(t, err)
+	require.Equal(t, 8, nr)
+
+	nr, err = colNumber(header, "random_col_name")
+	require.NotNil(t, err)
+	require.Equal(t, -1, nr)
+
+	nr, err = colNumber(header, "TCtypo")
+	require.NotNil(t, err)
+	require.Equal(t, -1, nr)
+}

--- a/ziffy/node/receiver.go
+++ b/ziffy/node/receiver.go
@@ -1,0 +1,166 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv6"
+)
+
+const (
+	// Promiscuous sets the pcap handle promiscuous flag
+	Promiscuous = false
+	// RecvTimeout sets the resolution for the listener
+	RecvTimeout = 1 * time.Microsecond
+	// SnapshotLen sets max length of packets
+	SnapshotLen = 1024
+)
+
+// Receiver listens for PTP packets
+type Receiver struct {
+	Config *Config
+
+	runningHandlers int
+	*sync.Mutex
+}
+
+// Start listens for PTP packets and reply to sender
+func (r *Receiver) Start() error {
+	handle, err := pcap.OpenLive(r.Config.Device, SnapshotLen, Promiscuous, RecvTimeout)
+	if err != nil {
+		return fmt.Errorf("unable to open device interface: %w", err)
+	}
+	defer handle.Close()
+
+	filter := "udp and port " + strconv.Itoa(r.Config.DestinationPort)
+	if err := handle.SetBPFFilter(filter); err != nil {
+		return fmt.Errorf("unable to set BPF Filter: %w", err)
+	}
+
+	log.Infof("listening on port %v for PTP EVENT packets (SYNC/DELAY_REQ) with ZiffyHexa signature. Sending back the packets as icmp\n\n",
+		r.Config.DestinationPort)
+
+	r.Mutex = &sync.Mutex{}
+	r.runningHandlers = 0
+
+	pktSrc := gopacket.NewPacketSource(handle, handle.LinkType())
+	for pkt := range pktSrc.Packets() {
+		if r.incRunningHandlers() {
+			go r.handlePacket(pkt)
+		}
+	}
+	return nil
+}
+
+func (r *Receiver) incRunningHandlers() bool {
+	r.Lock()
+	defer r.Unlock()
+	if r.Config.PTPRecvHandlers > r.runningHandlers {
+		r.runningHandlers++
+		return true
+	}
+	return false
+}
+
+func (r *Receiver) decRunningHandlers() bool {
+	r.Lock()
+	defer r.Unlock()
+	r.runningHandlers--
+	return r.runningHandlers >= 0
+}
+
+func (r *Receiver) handlePacket(rawPacket gopacket.Packet) {
+	defer func() {
+		if !r.decRunningHandlers() {
+			log.Fatal("decRunningHandlers: number of goroutines negative")
+		}
+	}()
+
+	ptpSync, srcIP, srcPort, err := parseSyncPacket(rawPacket)
+	if err != nil {
+		log.Tracef("unable to parse PTP: %v", err)
+		return
+	}
+	if ptpSync.Header.ControlField != ZiffyHexa {
+		log.Tracef("no ziffy packet")
+		return
+	}
+
+	log.Debugf("Type=%v, CF=%v, sPort=%v, sPort2=%v, sIP=%v", ptpSync.Header.MessageType().String(),
+		ptpSync.Header.CorrectionField, ptpSync.Header.SourcePortIdentity.PortNumber, srcPort, srcIP)
+
+	if err := r.sendResponse(ptpSync, srcIP, rawPacket); err != nil {
+		log.Tracef("unable to send response: %v", err)
+		return
+	}
+}
+
+//sendResponse sends ICMPTypeTimeExceeded to sender
+func (r *Receiver) sendResponse(packet *ptp.SyncDelayReq, sourceIP string, rawPacket gopacket.Packet) error {
+	dst, err := net.ResolveIPAddr("ip6:ipv6-icmp", sourceIP)
+	if err != nil {
+		return fmt.Errorf("unable to resolve sender address: %w", err)
+	}
+	conn, err := net.ListenPacket("ip6:ipv6-icmp", "")
+	if err != nil {
+		return fmt.Errorf("unable to establish connection: %w", err)
+	}
+	defer conn.Close()
+
+	mess := icmp.Message{
+		Type: ipv6.ICMPTypeTimeExceeded, Code: 0,
+		Body: &icmp.RawBody{
+			Data: rawPacket.Data()[PTPUnusedSize:],
+		},
+	}
+	buf, err := mess.Marshal(nil)
+	if err != nil {
+		return fmt.Errorf("unable to marshal the icmp packet: %w", err)
+	}
+	if _, err := conn.WriteTo(buf, dst); err != nil {
+		return fmt.Errorf("unable to write to connection: %w", err)
+	}
+	return nil
+}
+
+func parseSyncPacket(packet gopacket.Packet) (*ptp.SyncDelayReq, string, string, error) {
+	ipHeader, ok := packet.NetworkLayer().(*layers.IPv6)
+	if !ok {
+		return nil, "", "", fmt.Errorf("unable to parse IPv6 Header")
+	}
+	udpHeader, ok := packet.TransportLayer().(*layers.UDP)
+	if !ok {
+		return nil, "", "", fmt.Errorf("unable to parse UDP Header")
+	}
+
+	ptpPacket, err := ptp.DecodePacket(packet.ApplicationLayer().Payload())
+	if err != nil {
+		return nil, "", "", fmt.Errorf("unable to decode ptp packet: %w", err)
+	}
+	return ptpPacket.(*ptp.SyncDelayReq), ipHeader.SrcIP.String(), strconv.Itoa(int(udpHeader.SrcPort)), nil
+}

--- a/ziffy/node/receiver_test.go
+++ b/ziffy/node/receiver_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/require"
+)
+
+// rawPTP packet received from sender
+var rawPTP = []byte{
+	0xb8, 0xce, 0xf6, 0x61, 0x00, 0x80, 0xc2, 0x18, 0x50, 0x09, 0xca, 0x4e, 0x86, 0xdd, 0x60, 0x00,
+	0x00, 0x00, 0x00, 0x36, 0x11, 0x01, 0xfa, 0xce, 0xdb, 0x00, 0xfa, 0xce, 0x12, 0x02, 0xfa, 0xce,
+	0x00, 0x00, 0xfa, 0xce, 0x00, 0xff, 0xfa, 0xce, 0xdb, 0x00, 0xfa, 0xce, 0x26, 0x08, 0xfa, 0xce,
+	0x00, 0x00, 0xfa, 0xce, 0x00, 0xff, 0x80, 0x02, 0x01, 0x3f, 0x00, 0x36, 0x51, 0xeb, 0x00, 0x02,
+	0x00, 0x2c, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x57, 0x10, 0x05, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x02, 0x00, 0x06, 0xff, 0x7f,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestIncRunningHandlers(t *testing.T) {
+	r := Receiver{
+		Config:          &Config{PTPRecvHandlers: 2},
+		Mutex:           &sync.Mutex{},
+		runningHandlers: 0,
+	}
+
+	require.Equal(t, 0, r.runningHandlers)
+	require.Equal(t, true, r.incRunningHandlers())
+	require.Equal(t, 1, r.runningHandlers)
+	require.Equal(t, true, r.incRunningHandlers())
+	require.Equal(t, 2, r.runningHandlers)
+	require.Equal(t, false, r.incRunningHandlers())
+	require.Equal(t, 2, r.runningHandlers)
+}
+
+func TestDecRunningHandlers(t *testing.T) {
+	r := Receiver{
+		Config:          &Config{PTPRecvHandlers: 2},
+		Mutex:           &sync.Mutex{},
+		runningHandlers: 2,
+	}
+
+	require.Equal(t, true, r.decRunningHandlers())
+	require.Equal(t, 1, r.runningHandlers)
+	require.Equal(t, true, r.decRunningHandlers())
+	require.Equal(t, 0, r.runningHandlers)
+	require.Equal(t, false, r.decRunningHandlers())
+}
+
+func TestHandlePacket(t *testing.T) {
+	packet := gopacket.NewPacket(rawPTP, layers.LinkTypeEthernet, gopacket.DecodeOptions{Lazy: true, NoCopy: true})
+
+	r := Receiver{
+		Config:          &Config{PTPRecvHandlers: 3},
+		Mutex:           &sync.Mutex{},
+		runningHandlers: 0,
+	}
+
+	require.Equal(t, true, r.incRunningHandlers())
+	require.Equal(t, true, r.incRunningHandlers())
+	require.Equal(t, true, r.incRunningHandlers())
+	require.Equal(t, false, r.incRunningHandlers())
+	r.handlePacket(packet)
+	r.handlePacket(packet)
+	r.handlePacket(packet)
+	require.Equal(t, true, r.incRunningHandlers())
+}
+
+func TestParseSyncPacket(t *testing.T) {
+	packet := gopacket.NewPacket(rawPTP, layers.LinkTypeEthernet, gopacket.DecodeOptions{Lazy: true, NoCopy: true})
+
+	ptpPacket, srcIP, srcPort, err := parseSyncPacket(packet)
+	require.Nil(t, err)
+	require.Equal(t, uint8(ZiffyHexa), ptpPacket.ControlField)
+	require.Equal(t, "face:db00:face:1202:face:0:face:ff", srcIP)
+	require.Equal(t, strconv.Itoa(32770), srcPort)
+	require.Equal(t, uint16(32770), ptpPacket.SourcePortIdentity.PortNumber)
+}

--- a/ziffy/node/sender.go
+++ b/ziffy/node/sender.go
@@ -1,0 +1,367 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sort"
+	"syscall"
+	"time"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/ipv6"
+)
+
+const (
+	// RackMaskBits identifies the rack ipv6 prefix
+	RackMaskBits = 64
+	// FaceHexaTop is the upper byte of 0xface
+	FaceHexaTop = 0xfa
+	// FaceHexaBot is the lower byte of 0xface
+	FaceHexaBot = 0xce
+	// LLDPTypeStr Ether type string
+	LLDPTypeStr = "0x88cc"
+)
+
+// Sender sweeps the network with PTP packets
+type Sender struct {
+	Config *Config
+
+	icmpConn *net.IPConn
+
+	inputQueue chan *SwitchTrafficInfo
+	icmpDone   chan bool
+
+	routes         []PathInfo
+	destHop        int
+	rackSwHostname string
+
+	currentRoute int
+}
+
+// Start sending PTP packets
+func (s *Sender) Start() ([]PathInfo, error) {
+	icmpAddr, err := net.ResolveIPAddr("ip6:ipv6-icmp", "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve source address: %w", err)
+	}
+	icmpConn, err := net.ListenIP("ip6:ipv6-icmp", icmpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to listen to icmp: %w", err)
+	}
+	defer icmpConn.Close()
+
+	if s.rackSwHostname, err = rackSwHostnameMonitor(s.Config.Device, s.Config.LLDPWaitTime); err != nil {
+		log.Warn("unable to learn name of rack switch via LLDP")
+	}
+
+	s.inputQueue = make(chan *SwitchTrafficInfo, s.Config.QueueCap)
+	s.icmpDone = make(chan bool)
+	s.icmpConn = icmpConn
+	s.currentRoute = 0
+
+	go s.monitorIcmp(s.icmpConn)
+
+	log.Infof("sending %v flows of PTP %v packets to %v from source port range %v-%v with max hop count of %v and min hop count of %v and "+
+		"sweeping %v other addresses in target network prefix with a per hop timeout of %v. Total flows %v.\n\n",
+		s.Config.PortCount, s.Config.MessageType, s.Config.DestinationAddress,
+		s.Config.SourcePort, s.Config.SourcePort+s.Config.PortCount-1, s.Config.HopMax, s.Config.HopMin, s.Config.IPCount, s.Config.IcmpTimeout,
+		s.Config.PortCount+s.Config.PortCount*s.Config.IPCount)
+
+	for i := 0; i < s.Config.PortCount; i++ {
+		s.routes = append(s.routes, PathInfo{switches: nil, rackSwHostname: s.rackSwHostname})
+		_, err := s.traceRoute(s.Config.DestinationAddress, s.Config.SourcePort+i, false)
+		if err != nil {
+			log.Errorf("traceRoute failed: %v", err)
+			continue
+		}
+
+		s.currentRoute++
+		s.popAllQueue()
+	}
+	if s.Config.IPCount != 0 {
+		s.sweepRackPrefix()
+	}
+
+	// Waiting for late packets, if any
+	time.Sleep(s.Config.IcmpReplyTime)
+	s.popAllQueue()
+
+	s.icmpDone <- true
+	return s.clearPaths(), nil
+}
+
+// Insert late packets into corresponding path
+// Fixes the scenario in which packets arrive after traceRoute finished
+func (s *Sender) popAllQueue() {
+	for len(s.inputQueue) > 0 {
+		sw := <-s.inputQueue
+		s.routes[sw.routeIdx].switches = append(s.routes[sw.routeIdx].switches, *sw)
+	}
+}
+
+func sortSwitchesByHop(swArray []SwitchTrafficInfo) {
+	sort.Slice(swArray, func(i, j int) bool {
+		return swArray[i].hop < swArray[j].hop
+	})
+}
+
+// clearPaths fixes corner case scenarios
+func (s *Sender) clearPaths() []PathInfo {
+	var retPaths []PathInfo
+	idx := 0
+	for _, route := range s.routes {
+		retPaths = append(retPaths, PathInfo{switches: nil, rackSwHostname: s.rackSwHostname})
+		// Sort each route. This fixes the scenario where a
+		// packet with lower hop arrives after a packet with higher hop
+		sortSwitchesByHop(route.switches)
+		for j, sw := range route.switches {
+			// Strip out duplicate ICMP replies to address issue where
+			// switch sends more than one ICMP Hop Limit Exceeded message with same hop number
+			if j != len(route.switches)-1 && route.switches[j].hop == route.switches[j+1].hop {
+				continue
+			}
+			retPaths[idx].switches = append(retPaths[idx].switches, sw)
+		}
+		idx++
+	}
+	return retPaths
+}
+
+// sweepRackPrefix iterates over additional IP addresses
+// (within the same /64 as the destination IP) and targets
+// those addresses.
+func (s *Sender) sweepRackPrefix() {
+	for i := 1; i <= s.Config.IPCount; i++ {
+		newIP := s.formNewDest(i)
+		for j := 0; j < s.Config.PortCount; j++ {
+			s.routes = append(s.routes, PathInfo{rackSwHostname: s.rackSwHostname})
+
+			if _, err := s.traceRoute(newIP.String(), s.Config.SourcePort+j, true); err != nil {
+				log.Errorf("sweepRackPrefix traceRoute failed: %v", err)
+				continue
+			}
+			s.currentRoute++
+
+			s.popAllQueue()
+		}
+		fmt.Printf("\r %v/%v IPs tested. Current: %v", i, s.Config.IPCount, newIP.String())
+	}
+	fmt.Printf("\n\n")
+}
+
+func (s *Sender) traceRoute(destinationIP string, sendingPort int, sweep bool) ([]SwitchTrafficInfo, error) {
+	var route []SwitchTrafficInfo
+	ptpAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(destinationIP, fmt.Sprint(s.Config.DestinationPort)))
+	if err != nil {
+		return nil, fmt.Errorf("traceRoute unable to resolve UDPAddr: %w", err)
+	}
+	ptpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(""), Port: sendingPort})
+	if err != nil {
+		return nil, fmt.Errorf("traceRoute unable to establish connection: %w", err)
+	}
+	defer ptpConn.Close()
+
+	file, err := ptpConn.File()
+	if err != nil {
+		return nil, fmt.Errorf("traceRoute unable to open ptpConn file: %w", err)
+	}
+	defer file.Close()
+
+	destReached := false
+	hopMax := s.Config.HopMax
+
+	// if sweep is activated and the destination was found
+	if sweep && s.destHop > 0 {
+		hopMax = s.destHop - 1
+	}
+	// Stop incrementing hops when either the max hop count is reached or
+	// the destination has responded unless continue is specified
+	for hop := s.Config.HopMin; hop <= hopMax && (!destReached || s.Config.ContReached); hop++ {
+		if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_UNICAST_HOPS, hop); err != nil {
+			return route, err
+		}
+		// First 2 bits from Traffic Class are unused, so we shift the value 2 bits
+		if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_TCLASS, s.Config.DSCP<<2); err != nil {
+			return route, err
+		}
+		if err := s.sendEventMsg(s.formSyncPacket(hop, s.currentRoute), ptpConn, ptpAddr); err != nil {
+			return route, err
+		}
+
+		select {
+		case sw := <-s.inputQueue:
+			s.routes[sw.routeIdx].switches = append(s.routes[sw.routeIdx].switches, *sw)
+			if sw.ip == ptpAddr.IP.String() {
+				destReached = true
+				s.destHop = hop
+			}
+		case <-time.After(s.Config.IcmpTimeout):
+			continue
+		}
+	}
+	return route, nil
+}
+
+func (s *Sender) sendEventMsg(p ptp.Packet, ptpConn *net.UDPConn, ptpAddr *net.UDPAddr) error {
+	b, err := ptp.Bytes(p)
+	if err != nil {
+		return err
+	}
+	_, err = ptpConn.WriteTo(b, ptpAddr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// formSyncPacket creates PTP SYNC header
+// SequenceId contains origin hop; PortNumber contains origin port;
+// ControlField contains the Zi(0xff)y identifier
+func (s *Sender) formSyncPacket(hop int, routeIndex int) *ptp.SyncDelayReq {
+	return &ptp.SyncDelayReq{
+		Header: ptp.Header{
+			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(s.Config.MessageType, 0),
+			Version:         ptp.Version,
+			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			FlagField:       ptp.FlagUnicast,
+			SequenceID:      uint16(hop),
+			SourcePortIdentity: ptp.PortIdentity{
+				PortNumber: uint16(routeIndex),
+			},
+			ControlField:       ZiffyHexa, //identifier for zi(0xff)y
+			LogMessageInterval: 0x7f,
+		},
+	}
+}
+
+func (s *Sender) monitorIcmp(conn net.PacketConn) {
+	buf := make([]byte, 128)
+	for {
+		select {
+		case <-s.icmpDone:
+			return
+		default:
+			n, rAddr, err := conn.ReadFrom(buf)
+			if err != nil {
+				log.Debugf("icmp listener error: %v", err)
+				continue
+			}
+			go s.handleIcmpPacket(buf, n, rAddr)
+		}
+	}
+}
+
+// handleIcmpPacket is a handler which gets called every time icmp packets arrive
+func (s *Sender) handleIcmpPacket(rawPacket []byte, len int, rAddr net.Addr) {
+	icmpType := rawPacket[0]
+	if ipv6.ICMPType(icmpType) != ipv6.ICMPTypeTimeExceeded {
+		log.Tracef("not ipv6 timeexceeded packet")
+		return
+	}
+	ptpOffset := Ipv6HeaderSize + UDPHeaderSize + ICMPHeaderSize
+	if ptpOffset > len {
+		log.Tracef("packet too short")
+		return
+	}
+	ptpPacket, err := ptp.DecodePacket(rawPacket[ptpOffset:len])
+	if err != nil {
+		log.Tracef("PTP not contained in ICMP")
+		return
+	}
+
+	s.inputQueue <- &SwitchTrafficInfo{
+		ip:        rAddr.String(),
+		corrField: ptpPacket.(*ptp.SyncDelayReq).Header.CorrectionField,
+		hop:       int(ptpPacket.(*ptp.SyncDelayReq).Header.SequenceID),
+		routeIdx:  int(ptpPacket.(*ptp.SyncDelayReq).Header.SourcePortIdentity.PortNumber),
+	}
+	log.Debugf("%v cf: %v hop: %v", getLookUpName(rAddr.String()), ptpPacket.(*ptp.SyncDelayReq).Header.CorrectionField, int(ptpPacket.(*ptp.SyncDelayReq).Header.SequenceID))
+}
+
+// formNewDest generates new ip address using the
+// rack prefix /64 of DestinationAddress by adding
+// :face:face:0:$i to the ipv6
+func (s *Sender) formNewDest(i int) net.IP {
+	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(s.Config.DestinationAddress, fmt.Sprintf("%d", s.Config.DestinationPort)))
+	if err != nil {
+		return nil
+	}
+	m := net.CIDRMask(RackMaskBits, 8*net.IPv6len)
+	maskIP := addr.IP.Mask(m)
+	ip := net.ParseIP(maskIP.String())
+	// add first :face: in the new ipv6
+	ip[8] += FaceHexaTop
+	ip[9] += FaceHexaBot
+	// add second :face: in the new ipv6
+	ip[10] += FaceHexaTop
+	ip[11] += FaceHexaBot
+	// add argument i at the end of the new ipv6
+	ip[len(ip)-1] += byte(i)
+	ip[len(ip)-2] += byte(i >> 8)
+	// if rack switch /64 is 2401:db00:251c:2608:: and i is 4
+	// resulting ip is 2401:db00:251c:2608:face:face:0:4
+	return net.IP(ip)
+}
+
+// rackSwHostname listens to lldp packets from rack switch
+func rackSwHostnameMonitor(device string, lldpTimeout time.Duration) (string, error) {
+	log.Info("listening for LLDP packets from rack switch")
+
+	handle, err := pcap.OpenLive(device, SnapshotLen, true, RecvTimeout)
+	if err != nil {
+		return "", fmt.Errorf("unable to OpenLive: %w", err)
+	}
+	defer handle.Close()
+
+	filter := "ether proto " + LLDPTypeStr
+	if err := handle.SetBPFFilter(filter); err != nil {
+		return "", fmt.Errorf("unable to set BPF Filter: %w", err)
+	}
+
+	rackChan := make(chan string, 1)
+	go func() {
+		pktSrc := gopacket.NewPacketSource(handle, handle.LinkType())
+		for pkt := range pktSrc.Packets() {
+			p := gopacket.NewPacket(pkt.Data(), layers.LinkTypeEthernet, gopacket.DecodeOptions{})
+			info := p.Layer(layers.LayerTypeLinkLayerDiscoveryInfo)
+			rackChan <- info.(*layers.LinkLayerDiscoveryInfo).SysName
+			break
+		}
+	}()
+
+	select {
+	case res := <-rackChan:
+		return res, nil
+	case <-time.After(lldpTimeout):
+		return "", fmt.Errorf("unable to get rack hostname")
+	}
+}
+
+func getLookUpName(ip string) string {
+	addr, err := net.LookupAddr(ip)
+	if err != nil {
+		return ip
+	}
+	return addr[0]
+}

--- a/ziffy/node/sender_test.go
+++ b/ziffy/node/sender_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+)
+
+func TestPopAllQueue(t *testing.T) {
+	s := Sender{
+		Config: &Config{QueueCap: 10000},
+	}
+	numInfos := 5
+	numRoutes := 2
+
+	s.inputQueue = make(chan *SwitchTrafficInfo, s.Config.QueueCap)
+
+	s.routes = append(s.routes, PathInfo{switches: nil})
+	s.routes = append(s.routes, PathInfo{switches: nil})
+
+	for i := 0; i <= numInfos; i++ {
+		s.inputQueue <- &SwitchTrafficInfo{
+			hop:      i,
+			routeIdx: i % numRoutes,
+		}
+	}
+	s.popAllQueue()
+
+	require.Equal(t, 0, s.routes[0].switches[0].hop)
+	require.Equal(t, 2, s.routes[0].switches[1].hop)
+	require.Equal(t, 4, s.routes[0].switches[2].hop)
+
+	require.Equal(t, 1, s.routes[1].switches[0].hop)
+	require.Equal(t, 3, s.routes[1].switches[1].hop)
+	require.Equal(t, 5, s.routes[1].switches[2].hop)
+}
+
+func TestClearPaths(t *testing.T) {
+	s := Sender{
+		Config: &Config{DestinationAddress: "2401:db00:251c:2608:1:2:c:d"},
+	}
+	noOrderIndex := 0
+	noOrderPath := []SwitchTrafficInfo{
+		SwitchTrafficInfo{hop: 1, routeIdx: 1},
+		SwitchTrafficInfo{hop: 4, routeIdx: 1},
+		SwitchTrafficInfo{hop: 2, routeIdx: 1},
+	}
+	duplicateIndex := 1
+	duplicatePath := []SwitchTrafficInfo{
+		SwitchTrafficInfo{hop: 1, routeIdx: 1},
+		SwitchTrafficInfo{hop: 2, routeIdx: 1},
+		SwitchTrafficInfo{hop: 2, routeIdx: 1},
+		SwitchTrafficInfo{hop: 3, routeIdx: 1},
+	}
+	s.routes = append(s.routes, PathInfo{switches: noOrderPath})
+	s.routes = append(s.routes, PathInfo{switches: duplicatePath})
+
+	res := s.clearPaths()
+	require.Equal(t, 1, res[noOrderIndex].switches[0].hop)
+	require.Equal(t, 2, res[noOrderIndex].switches[1].hop)
+	require.Equal(t, 4, res[noOrderIndex].switches[2].hop)
+
+	require.Equal(t, 1, res[duplicateIndex].switches[0].hop)
+	require.Equal(t, 2, res[duplicateIndex].switches[1].hop)
+	require.Equal(t, 3, res[duplicateIndex].switches[2].hop)
+	require.Equal(t, 3, len(res[duplicateIndex].switches))
+}
+
+func TestSortSwitchesByHop(t *testing.T) {
+	var switches []SwitchTrafficInfo
+	switches = append(switches, SwitchTrafficInfo{hop: 3, routeIdx: 1})
+	switches = append(switches, SwitchTrafficInfo{hop: 1, routeIdx: 2})
+	switches = append(switches, SwitchTrafficInfo{hop: 10, routeIdx: 5})
+	switches = append(switches, SwitchTrafficInfo{hop: 21, routeIdx: 5})
+	switches = append(switches, SwitchTrafficInfo{hop: 5, routeIdx: 5})
+
+	sortSwitchesByHop(switches)
+	require.Equal(t, 1, switches[0].hop)
+	require.Equal(t, 2, switches[0].routeIdx)
+
+	require.Equal(t, 3, switches[1].hop)
+	require.Equal(t, 1, switches[1].routeIdx)
+
+	require.Equal(t, 5, switches[2].hop)
+	require.Equal(t, 5, switches[2].routeIdx)
+
+	require.Equal(t, 10, switches[3].hop)
+	require.Equal(t, 5, switches[3].routeIdx)
+
+	require.Equal(t, 21, switches[4].hop)
+	require.Equal(t, 5, switches[4].routeIdx)
+}
+
+func TestFormNewDest(t *testing.T) {
+	s := Sender{
+		Config: &Config{DestinationAddress: "2401:db00:251c:2608:1:2:c:d"},
+	}
+
+	ip := s.formNewDest(4)
+	require.Equal(t, "2401:db00:251c:2608:face:face:0:4", ip.String())
+	ip = s.formNewDest(int(0xffff))
+	require.Equal(t, "2401:db00:251c:2608:face:face:0:ffff", ip.String())
+	ip = s.formNewDest(int(0xab))
+	require.Equal(t, "2401:db00:251c:2608:face:face:0:ab", ip.String())
+	ip = s.formNewDest(int(0xabcdef))
+	require.Equal(t, "2401:db00:251c:2608:face:face:0:cdef", ip.String())
+}
+
+func TestSweepRackPrefix(t *testing.T) {
+	s := Sender{
+		Config: &Config{
+			DestinationAddress: "2401:db00:251c:2608:1:2:c:d",
+			IPCount:            3,
+			PortCount:          5,
+		},
+	}
+
+	s.routes = append(s.routes, PathInfo{switches: []SwitchTrafficInfo{}})
+	s.sweepRackPrefix()
+	require.Equal(t, 16, len(s.routes))
+	s.routes = append(s.routes, PathInfo{switches: []SwitchTrafficInfo{}})
+	s.routes = append(s.routes, PathInfo{switches: []SwitchTrafficInfo{}})
+	s.sweepRackPrefix()
+	require.Equal(t, 33, len(s.routes))
+}
+
+func TestFormSyncPacket(t *testing.T) {
+	s := Sender{
+		Config: &Config{
+			DestinationAddress: "2401:db00:251c:2608:1:2:c:d",
+			IPCount:            3,
+			PortCount:          5,
+			HopMax:             3,
+			HopMin:             1,
+			MessageType:        ptp.MessageSync,
+		},
+	}
+
+	pkt := s.formSyncPacket(4, 33000)
+	require.Equal(t, uint8(ZiffyHexa), pkt.ControlField)
+	require.Equal(t, uint16(4), pkt.SequenceID)
+	require.Equal(t, uint16(33000), pkt.SourcePortIdentity.PortNumber)
+	require.Equal(t, ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0), pkt.SdoIDAndMsgType)
+
+	s.Config.MessageType = ptp.MessageDelayReq
+	pkt = s.formSyncPacket(7, 12345)
+	require.Equal(t, uint8(ZiffyHexa), pkt.ControlField)
+	require.Equal(t, uint16(7), pkt.SequenceID)
+	require.Equal(t, uint16(12345), pkt.SourcePortIdentity.PortNumber)
+	require.Equal(t, ptp.NewSdoIDAndMsgType(ptp.MessageDelayReq, 0), pkt.SdoIDAndMsgType)
+}
+
+func TestRackSwHostnameMonitor(t *testing.T) {
+	rackSwHostname, err := rackSwHostnameMonitor("non-existing-eth", 1*time.Second)
+	require.NotNil(t, err)
+	require.Equal(t, "", rackSwHostname)
+
+	rackSwHostname, err = rackSwHostnameMonitor("another-non-eth", 1*time.Second)
+	require.NotNil(t, err)
+	require.NotNil(t, "", rackSwHostname)
+}


### PR DESCRIPTION
## Summary

This diff adds Ziffy, a CLI tool intended to triangulate datacenter switches that are not operating correctly as PTP TCs.

## Test Plan

Unit tests; Tests between two internal hosts.