### PR TITLE
Change way to select worker hash->rand.Seed

### DIFF
--- a/ptp4u/server/worker.go
+++ b/ptp4u/server/worker.go
@@ -231,6 +231,7 @@ func (s *sendWorker) inventoryClients() {
 				continue
 			}
 			s.stats.IncSubscription(st)
+			s.stats.IncWorkerSubs(s.id)
 		}
 	}
 }

--- a/ptp4u/stats/json.go
+++ b/ptp4u/stats/json.go
@@ -63,6 +63,7 @@ func (s *JSONStats) Snapshot() {
 	s.rxSignaling.copy(&s.report.rxSignaling)
 	s.txSignaling.copy(&s.report.txSignaling)
 	s.workerQueue.copy(&s.report.workerQueue)
+	s.workerSubs.copy(&s.report.workerSubs)
 	s.txtsattempts.copy(&s.report.txtsattempts)
 	s.report.utcoffset = s.utcoffset
 }
@@ -110,6 +111,11 @@ func (s *JSONStats) IncTXSignaling(t ptp.MessageType) {
 	s.txSignaling.inc(int(t))
 }
 
+// IncWorkerSubs atomically add 1 to the counter
+func (s *JSONStats) IncWorkerSubs(workerid int) {
+	s.workerSubs.inc(workerid)
+}
+
 // DecSubscription atomically removes 1 from the counter
 func (s *JSONStats) DecSubscription(t ptp.MessageType) {
 	s.subscriptions.dec(int(t))
@@ -133,6 +139,11 @@ func (s *JSONStats) DecRXSignaling(t ptp.MessageType) {
 // DecTXSignaling atomically removes 1 from the counter
 func (s *JSONStats) DecTXSignaling(t ptp.MessageType) {
 	s.txSignaling.dec(int(t))
+}
+
+// DecWorkerSubs atomically removes 1 from the counter
+func (s *JSONStats) DecWorkerSubs(workerid int) {
+	s.workerSubs.dec(workerid)
 }
 
 // SetMaxWorkerQueue atomically sets worker queue len

--- a/ptp4u/stats/json_test.go
+++ b/ptp4u/stats/json_test.go
@@ -110,6 +110,16 @@ func TestJSONStatsSetMaxWorkerQueue(t *testing.T) {
 	require.Equal(t, int64(42), stats.workerQueue.load(10))
 }
 
+func TestJSONStatsWorkerSubs(t *testing.T) {
+	stats := NewJSONStats()
+
+	stats.IncWorkerSubs(10)
+	require.Equal(t, int64(1), stats.workerSubs.load(10))
+
+	stats.DecWorkerSubs(10)
+	require.Equal(t, int64(0), stats.tx.load(10))
+}
+
 func TestJSONStatsSetMaxTXTSAttempts(t *testing.T) {
 	stats := NewJSONStats()
 

--- a/ptp4u/stats/stats.go
+++ b/ptp4u/stats/stats.go
@@ -56,6 +56,9 @@ type Stats interface {
 	// IncTXSignaling atomically add 1 to the counter
 	IncTXSignaling(t ptp.MessageType)
 
+	// IncWorkerSubs atomically add 1 to the counter
+	IncWorkerSubs(workerid int)
+
 	// DecSubscription atomically removes 1 from the counter
 	DecSubscription(t ptp.MessageType)
 
@@ -70,6 +73,9 @@ type Stats interface {
 
 	// DecTXSignaling atomically removes 1 from the counter
 	DecTXSignaling(t ptp.MessageType)
+
+	// DecWorkerSubs atomically removes 1 from the counter
+	DecWorkerSubs(workerid int)
 
 	// SetMaxWorkerQueue atomically sets worker queue len
 	SetMaxWorkerQueue(workerid int, queue int64)
@@ -156,6 +162,7 @@ type counters struct {
 	txSignaling   syncMapInt64
 	txtsattempts  syncMapInt64
 	workerQueue   syncMapInt64
+	workerSubs    syncMapInt64
 	utcoffset     int64
 }
 
@@ -166,6 +173,7 @@ func (c *counters) init() {
 	c.rxSignaling.init()
 	c.txSignaling.init()
 	c.workerQueue.init()
+	c.workerSubs.init()
 	c.txtsattempts.init()
 }
 
@@ -176,6 +184,7 @@ func (c *counters) reset() {
 	c.rxSignaling.reset()
 	c.txSignaling.reset()
 	c.workerQueue.reset()
+	c.workerSubs.reset()
 	c.txtsattempts.reset()
 	c.utcoffset = 0
 }
@@ -217,6 +226,11 @@ func (c *counters) toMap() (export map[string]int64) {
 	for _, t := range c.workerQueue.keys() {
 		c := c.workerQueue.load(t)
 		res[fmt.Sprintf("worker.%d.queue", t)] = c
+	}
+
+	for _, t := range c.workerSubs.keys() {
+		c := c.workerSubs.load(t)
+		res[fmt.Sprintf("worker.%d.subscriptions", t)] = c
 	}
 
 	for _, t := range c.txtsattempts.keys() {

--- a/ptp4u/stats/stats_test.go
+++ b/ptp4u/stats/stats_test.go
@@ -70,6 +70,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	c.rxSignaling.store(1, 1)
 	c.txSignaling.store(1, 1)
 	c.workerQueue.store(1, 1)
+	c.workerSubs.store(1, 1)
 	c.txtsattempts.store(1, 1)
 	c.utcoffset = 1
 
@@ -79,6 +80,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(1), c.rxSignaling.load(1))
 	require.Equal(t, int64(1), c.txSignaling.load(1))
 	require.Equal(t, int64(1), c.workerQueue.load(1))
+	require.Equal(t, int64(1), c.workerSubs.load(1))
 	require.Equal(t, int64(1), c.txtsattempts.load(1))
 	require.Equal(t, int64(1), c.utcoffset)
 
@@ -90,6 +92,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(0), c.rxSignaling.load(1))
 	require.Equal(t, int64(0), c.txSignaling.load(1))
 	require.Equal(t, int64(0), c.workerQueue.load(1))
+	require.Equal(t, int64(0), c.workerSubs.load(1))
 	require.Equal(t, int64(0), c.txtsattempts.load(1))
 	require.Equal(t, int64(0), c.utcoffset)
 }


### PR DESCRIPTION
## Summary

Hash is a great and powerful mechanism to evenly distribute all clients over the workers. However, we don't need all mighty of hash and in fact it's very expensive in allocations:
```
$ go tool pprof -alloc_objects ~/heap.out
File: ptp4u_oleg
Build ID: 76cd8b1a79251dee5c07210a4129e9b3
Type: alloc_objects
Time: Aug 28, 2021 at 2:32am (PDT)
Duration: 1mins, Total samples = 27398529
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 27393068, 100% of 27398529 total
Dropped 1 node (cum <= 136992)
Showing top 10 nodes out of 18
      flat  flat%   sum%        cum   cum%
  16273390 59.40% 59.40%   21008655 76.68%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
   4923693 17.97% 77.37%    4923693 17.97%  third-party-source/go/golang.org/x/sys/unix.anyToSockaddr
-> 4620360 16.86% 94.23%    4620360 16.86%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).findWorker
    950293  3.47% 97.70%     950293  3.47%  github.com/facebookincubator/ptp/protocol.(*Signaling).UnmarshalBinary
    408420  1.49% 99.19%     408420  1.49%  github.com/facebookincubator/ptp/protocol.(*Signaling).MarshalBinary
    173221  0.63% 99.82%     361649  1.32%  third-party-source/go/golang.org/x/sys/unix.Recvfrom
     43691  0.16%   100%   13997495 51.09%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessages
         0     0%   100%     408420  1.49%  github.com/facebookincubator/ptp/protocol.Bytes
         0     0%   100%     950293  3.47%  github.com/facebookincubator/ptp/protocol.FromBytes
         0     0%   100%    9622900 35.12%  github.com/facebookincubator/ptp/protocol.ReadPacketWithRXTimestampBuf
(pprof)
```
(16% of all allocations in `ptp4u`)
What we really need is a way to get a number between 0 and "number of workers" and random allows just to do that with 0 allocations:
```
$ go tool pprof -alloc_objects ~/heap.out_hash
File: ptp4u_oleg
Build ID: 593f8c38a2075f87407dc5b4795b24d4
Type: alloc_objects
Time: Aug 29, 2021 at 2:11am (PDT)
Duration: 1mins, Total samples = 22946911
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 22943661, 100% of 22946911 total
Dropped 46 nodes (cum <= 114734)
Showing top 10 nodes out of 17
      flat  flat%   sum%        cum   cum%
  16624514 72.45% 72.45%   21466282 93.55%  third-party-source/go/golang.org/x/sys/unix.Recvmsg
   4940078 21.53% 93.98%    4940078 21.53%  third-party-source/go/golang.org/x/sys/unix.anyToSockaddr
    802834  3.50% 97.47%     802834  3.50%  github.com/facebookincubator/ptp/protocol.(*Signaling).UnmarshalBinary
    398337  1.74% 99.21%     398337  1.74%  github.com/facebookincubator/ptp/protocol.(*Signaling).MarshalBinary
    112360  0.49% 99.70%     210670  0.92%  third-party-source/go/golang.org/x/sys/unix.Recvfrom
     65538  0.29%   100%   10019660 43.66%  github.com/facebookincubator/ptp/ptp4u/server.(*Server).handleEventMessages
         0     0%   100%     398337  1.74%  github.com/facebookincubator/ptp/protocol.Bytes
         0     0%   100%     802834  3.50%  github.com/facebookincubator/ptp/protocol.FromBytes
         0     0%   100%    9954122 43.38%  github.com/facebookincubator/ptp/protocol.ReadPacketWithRXTimestampBuf
         0     0%   100%   11512160 50.17%  github.com/facebookincubator/ptp/protocol.ReadTXtimestampBuf
```
## Test Plan
To make sure we still have an even distribution we need a metric showing the number of subscriptions per worker (load was removed in https://github.com/facebookincubator/ptp/pull/35). Both hash%number of workers and random between 0 and number of workers produce a very similar result:
### Hash
```
ptp.ptp4u.worker.0.subscriptions 1984
ptp.ptp4u.worker.1.subscriptions 1880
ptp.ptp4u.worker.10.subscriptions 1977
ptp.ptp4u.worker.11.subscriptions 1950
ptp.ptp4u.worker.12.subscriptions 1938
ptp.ptp4u.worker.13.subscriptions 2098
ptp.ptp4u.worker.14.subscriptions 2109
ptp.ptp4u.worker.15.subscriptions 1948
ptp.ptp4u.worker.16.subscriptions 2034
ptp.ptp4u.worker.17.subscriptions 2057
ptp.ptp4u.worker.18.subscriptions 2042
ptp.ptp4u.worker.19.subscriptions 1913
ptp.ptp4u.worker.2.subscriptions 2006
ptp.ptp4u.worker.20.subscriptions 2025
ptp.ptp4u.worker.21.subscriptions 1885
ptp.ptp4u.worker.22.subscriptions 2212
ptp.ptp4u.worker.23.subscriptions 1909
ptp.ptp4u.worker.24.subscriptions 1861
ptp.ptp4u.worker.25.subscriptions 1901
ptp.ptp4u.worker.26.subscriptions 1983
ptp.ptp4u.worker.27.subscriptions 1973
```
### Random
```
ptp.ptp4u.worker.0.subscriptions 2066
ptp.ptp4u.worker.1.subscriptions 1876
ptp.ptp4u.worker.10.subscriptions 2014
ptp.ptp4u.worker.11.subscriptions 1913
ptp.ptp4u.worker.12.subscriptions 2035
ptp.ptp4u.worker.13.subscriptions 1863
ptp.ptp4u.worker.14.subscriptions 1783
ptp.ptp4u.worker.15.subscriptions 1982
ptp.ptp4u.worker.16.subscriptions 1873
ptp.ptp4u.worker.17.subscriptions 2020
ptp.ptp4u.worker.18.subscriptions 1902
ptp.ptp4u.worker.19.subscriptions 1990
ptp.ptp4u.worker.2.subscriptions 1951
ptp.ptp4u.worker.20.subscriptions 1900
ptp.ptp4u.worker.21.subscriptions 2022
ptp.ptp4u.worker.22.subscriptions 1888
ptp.ptp4u.worker.23.subscriptions 2112
ptp.ptp4u.worker.24.subscriptions 2012
ptp.ptp4u.worker.25.subscriptions 1992
ptp.ptp4u.worker.26.subscriptions 2003
ptp.ptp4u.worker.27.subscriptions 2055
```