### PR TITLE
Check subscription expiration

### DIFF
--- a/ptp4u/server/server_test.go
+++ b/ptp4u/server/server_test.go
@@ -46,32 +46,29 @@ func TestServerInventoryClients(t *testing.T) {
 	sa := ptp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	scS1 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	w.RegisterSubscription(clipi1, ptp.MessageSync, scS1)
-	scS1.running = true
 	w.inventoryClients()
 	require.Equal(t, 1, len(w.clients))
 
 	scA1 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Now().Add(time.Minute))
 	w.RegisterSubscription(clipi1, ptp.MessageAnnounce, scA1)
-	scA1.running = true
 	w.inventoryClients()
 	require.Equal(t, 2, len(w.clients))
 
 	scS2 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSync, c, time.Second, time.Now().Add(time.Minute))
 	w.RegisterSubscription(clipi2, ptp.MessageSync, scS2)
-	scS2.running = true
 	w.inventoryClients()
 	require.Equal(t, 2, len(w.clients[ptp.MessageSync]))
 
 	// Shutting down
-	scS1.running = false
+	scS1.expire = time.Now()
 	w.inventoryClients()
 	require.Equal(t, 1, len(w.clients[ptp.MessageSync]))
 
-	scA1.running = false
+	scA1.expire = time.Now()
 	w.inventoryClients()
 	require.Equal(t, 0, len(w.clients[ptp.MessageAnnounce]))
 
-	scS2.running = false
+	scS2.expire = time.Now()
 	w.inventoryClients()
 	require.Equal(t, 0, len(w.clients[ptp.MessageSync]))
 }

--- a/ptp4u/server/worker.go
+++ b/ptp4u/server/worker.go
@@ -231,7 +231,7 @@ func (s *sendWorker) inventoryClients() {
 	defer s.mux.Unlock()
 	for st, subs := range s.clients {
 		for k, sc := range subs {
-			if !sc.Running() {
+			if sc.Expired() {
 				delete(subs, k)
 				continue
 			}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Because the delayResp subscription is not an active one nothing terminates it when it legitimately expires.
But since we actually know the duration of the subscription we can simplify how we track subscriptions, remove redundant variable and reuse a lot of code.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### Before
![Screenshot 2021-09-07 at 15 32 06](https://user-images.githubusercontent.com/4749052/132363076-2a8aaefb-96a1-4d76-9159-6f72c6fa0025.png)
### After
![Screenshot 2021-09-07 at 15 32 54](https://user-images.githubusercontent.com/4749052/132363098-96c94ab0-fe0e-4dd8-9195-087b4b52fe10.png)

