### PR TITLE
[ziffy] support sending signaling packets

### DIFF
--- a/ziffy/main.go
+++ b/ziffy/main.go
@@ -70,7 +70,7 @@ func main() {
 	flag.IntVar(&c.DestinationPort, "dp", ptp.PortEvent, "destination port to send packets to")
 	flag.IntVar(&c.SourcePort, "sp", 32768, "the base source port to start probing (used by sender)")
 	flag.IntVar(&c.PortCount, "portcount", 1, "port count to be used for probing each target ip (used by sender)")
-	flag.StringVar(&messageType, "type", "sync", "set the message type. Can be sync (default) or delay_req (used by sender)")
+	flag.StringVar(&messageType, "type", "sync", "set the message type. Can be 'sync' (default), 'delay_req' or 'signaling' (used by sender)")
 	flag.StringVar(&c.CsvFile, "csv", "", "csv output file path (used by sender)")
 	flag.BoolVar(&c.ContReached, "continue", false, "continue incrementing hop count after destination host responds (used by sender)")
 	flag.IntVar(&c.IPCount, "ipcount", 0, "number of additional IPs targeted in the same /64 prefix as destination to increase hashing entropy (used by sender)")
@@ -99,6 +99,8 @@ func main() {
 		c.MessageType = ptp.MessageDelayReq
 	case "sync":
 		c.MessageType = ptp.MessageSync
+	case "signaling":
+		c.MessageType = ptp.MessageSignaling
 	default:
 		log.Fatalf("unsupported message type %q", messageType)
 	}

--- a/ziffy/node/packets.go
+++ b/ziffy/node/packets.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/binary"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+)
+
+// formSignalingPacket creates PTP SIGNALING packet
+// SequenceId contains origin hop; PortNumber contains origin port;
+// ControlField contains the Zi(0xff)y identifier
+func formSignalingPacket(hop int, routeIndex int) *ptp.Signaling {
+	l := binary.Size(ptp.Header{}) + binary.Size(ptp.PortIdentity{}) + binary.Size(ptp.RequestUnicastTransmissionTLV{})
+	return &ptp.Signaling{
+		Header: ptp.Header{
+			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageSignaling, 0),
+			Version:         ptp.Version,
+			SequenceID:      uint16(hop),
+			MessageLength:   uint16(l),
+			FlagField:       ptp.FlagUnicast,
+			SourcePortIdentity: ptp.PortIdentity{
+				PortNumber: uint16(routeIndex),
+			},
+			ControlField:       ZiffyHexa, //identifier for zi(0xff)y
+			LogMessageInterval: 0x7f,
+		},
+		TargetPortIdentity: ptp.PortIdentity{
+			PortNumber:    0xffff,
+			ClockIdentity: 0xffffffffffffffff,
+		},
+		TLVs: []ptp.TLV{
+			&ptp.RequestUnicastTransmissionTLV{
+				TLVHead: ptp.TLVHead{
+					TLVType:     ptp.TLVRequestUnicastTransmission,
+					LengthField: uint16(binary.Size(ptp.RequestUnicastTransmissionTLV{}) - binary.Size(ptp.TLVHead{})),
+				},
+				MsgTypeAndReserved:    ptp.NewUnicastMsgTypeAndFlags(ptp.MessageSync, 0),
+				LogInterMessagePeriod: 1,
+				DurationField:         0, // seconds
+			},
+		},
+	}
+}
+
+// formSyncPacket creates PTP SYNC packet
+// SequenceId contains origin hop; PortNumber contains origin port;
+// ControlField contains the Zi(0xff)y identifier
+func formSyncPacket(msgType ptp.MessageType, hop int, routeIndex int) *ptp.SyncDelayReq {
+	return &ptp.SyncDelayReq{
+		Header: ptp.Header{
+			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(msgType, 0),
+			Version:         ptp.Version,
+			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			FlagField:       ptp.FlagUnicast,
+			SequenceID:      uint16(hop),
+			SourcePortIdentity: ptp.PortIdentity{
+				PortNumber: uint16(routeIndex),
+			},
+			ControlField:       ZiffyHexa, //identifier for zi(0xff)y
+			LogMessageInterval: 0x7f,
+		},
+	}
+}

--- a/ziffy/node/packets_test.go
+++ b/ziffy/node/packets_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+
+	ptp "github.com/facebookincubator/ptp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormSyncPacket(t *testing.T) {
+	pkt := formSyncPacket(ptp.MessageSync, 4, 33000)
+	require.Equal(t, uint8(ZiffyHexa), pkt.ControlField)
+	require.Equal(t, uint16(4), pkt.SequenceID)
+	require.Equal(t, uint16(33000), pkt.SourcePortIdentity.PortNumber)
+	require.Equal(t, ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0), pkt.SdoIDAndMsgType)
+
+	pkt = formSyncPacket(ptp.MessageDelayReq, 7, 12345)
+	require.Equal(t, uint8(ZiffyHexa), pkt.ControlField)
+	require.Equal(t, uint16(7), pkt.SequenceID)
+	require.Equal(t, uint16(12345), pkt.SourcePortIdentity.PortNumber)
+	require.Equal(t, ptp.NewSdoIDAndMsgType(ptp.MessageDelayReq, 0), pkt.SdoIDAndMsgType)
+}

--- a/ziffy/node/sender_test.go
+++ b/ziffy/node/sender_test.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	ptp "github.com/facebookincubator/ptp/protocol"
 )
 
 func TestPopAllQueue(t *testing.T) {
@@ -141,32 +139,6 @@ func TestSweepRackPrefix(t *testing.T) {
 	s.routes = append(s.routes, PathInfo{switches: []SwitchTrafficInfo{}})
 	s.sweepRackPrefix()
 	require.Equal(t, 33, len(s.routes))
-}
-
-func TestFormSyncPacket(t *testing.T) {
-	s := Sender{
-		Config: &Config{
-			DestinationAddress: "2401:db00:251c:2608:1:2:c:d",
-			IPCount:            3,
-			PortCount:          5,
-			HopMax:             3,
-			HopMin:             1,
-			MessageType:        ptp.MessageSync,
-		},
-	}
-
-	pkt := s.formSyncPacket(4, 33000)
-	require.Equal(t, uint8(ZiffyHexa), pkt.ControlField)
-	require.Equal(t, uint16(4), pkt.SequenceID)
-	require.Equal(t, uint16(33000), pkt.SourcePortIdentity.PortNumber)
-	require.Equal(t, ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0), pkt.SdoIDAndMsgType)
-
-	s.Config.MessageType = ptp.MessageDelayReq
-	pkt = s.formSyncPacket(7, 12345)
-	require.Equal(t, uint8(ZiffyHexa), pkt.ControlField)
-	require.Equal(t, uint16(7), pkt.SequenceID)
-	require.Equal(t, uint16(12345), pkt.SourcePortIdentity.PortNumber)
-	require.Equal(t, ptp.NewSdoIDAndMsgType(ptp.MessageDelayReq, 0), pkt.SdoIDAndMsgType)
 }
 
 func TestRackSwHostnameMonitor(t *testing.T) {


### PR DESCRIPTION
## Summary

While sending 'signaling' packets doesn't show TC, it's still useful to be able to trace with them in case this specific packet type is dropped along the way, while others pass.

## Test Plan

tests pass

extensive manual testing shows the tool still works as expected
