### PR TITLE
fix hw timestamp initialization

### DIFF
--- a/ptp4u/server/server.go
+++ b/ptp4u/server/server.go
@@ -137,11 +137,11 @@ func (s *Server) startEventListener() {
 	switch s.Config.TimestampType {
 	case ptp.HWTIMESTAMP:
 		if err := ptp.EnableHWTimestampsSocket(s.eFd, s.Config.Interface); err != nil {
-			log.Fatalf("Cannot enable hardware RX timestamps")
+			log.Fatalf("Cannot enable hardware RX timestamps: %v", err)
 		}
 	case ptp.SWTIMESTAMP:
 		if err := ptp.EnableSWTimestampsSocket(s.eFd); err != nil {
-			log.Fatalf("Cannot enable software RX timestamps")
+			log.Fatalf("Cannot enable software RX timestamps: %v", err)
 		}
 	default:
 		log.Fatalf("Unrecognized timestamp type: %s", s.Config.TimestampType)


### PR DESCRIPTION
## Summary

We used `hwtstampСonfig` with wrong int size, and it still somehow worked on Mellanox. Not so much with Broadcom:
```
failed to enable RX hardware timestamps: failed to run ioctl SIOCSHWTSTAMP: 34
```

This PR:
* fixed the int size of `hwtstampСonfig` fields
* added fallback to `HWTSTAMP_FILTER_PTP_V2_EVENT` in case the NIC doesn't support timestamping all packets.
* fixed failure logging in ptp4u server listener

## Test Plan

ran ptp4u on Mellanox and Broadcom, tested against `ptpcheck trace`, all works as expected.