### PR TITLE
bump to IEEE 1588-2019 version, fix lengths for management packets

### DIFF
--- a/protocol/management_test.go
+++ b/protocol/management_test.go
@@ -39,7 +39,7 @@ func Test_parseMsgErrorStatus(t *testing.T) {
 		ManagementMsgHead: ManagementMsgHead{
 			Header: Header{
 				SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageManagement, 0),
-				Version:             2,
+				Version:             MajorVersion,
 				MessageLength:       uint16(len(raw) - 2),
 				DomainNumber:        0,
 				MinorSdoID:          0,

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -25,8 +25,13 @@ import (
 	"fmt"
 )
 
-// Version is what version of PTP protocol we implement
-const Version uint8 = 2
+// what version of PTP protocol we implement
+const (
+	MajorVersion     uint8 = 2
+	MinorVersion     uint8 = 1
+	Version          uint8 = MinorVersion<<4 | MajorVersion
+	MajorVersionMask uint8 = 0x0f
+)
 
 /* UDP port numbers
 The UDP destination port of a PTP event message shall be 319.

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -39,7 +39,7 @@ func Test_parseSync(t *testing.T) {
 	want := SyncDelayReq{
 		Header: Header{
 			SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageSync, 1),
-			Version:             2,
+			Version:             MajorVersion,
 			MessageLength:       44,
 			DomainNumber:        0,
 			MinorSdoID:          0,
@@ -86,7 +86,7 @@ func Test_parseFollowup(t *testing.T) {
 	want := FollowUp{
 		Header: Header{
 			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageFollowUp, 0),
-			Version:         Version,
+			Version:         MajorVersion,
 			MessageLength:   uint16(binary.Size(FollowUp{})),
 			DomainNumber:    0,
 			FlagField:       FlagUnicast,
@@ -132,7 +132,7 @@ func Test_parsePDelayReq(t *testing.T) {
 	want := PDelayReq{
 		Header: Header{
 			SdoIDAndMsgType:     NewSdoIDAndMsgType(MessagePDelayReq, 1),
-			Version:             2,
+			Version:             MajorVersion,
 			MessageLength:       54,
 			DomainNumber:        0,
 			MinorSdoID:          0,
@@ -182,7 +182,7 @@ func Test_parseAnnounce(t *testing.T) {
 	want := Announce{
 		Header: Header{
 			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageAnnounce, 0),
-			Version:         Version,
+			Version:         MajorVersion,
 			MessageLength:   uint16(binary.Size(Announce{})),
 			DomainNumber:    0,
 			FlagField:       FlagUnicast | FlagPTPTimescale,
@@ -236,7 +236,7 @@ func Test_parseDelayResp(t *testing.T) {
 	want := DelayResp{
 		Header: Header{
 			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageDelayResp, 0),
-			Version:         Version,
+			Version:         MajorVersion,
 			MessageLength:   uint16(binary.Size(DelayResp{})),
 			DomainNumber:    0,
 			FlagField:       FlagUnicast,
@@ -291,7 +291,7 @@ func BenchmarkWriteSync(b *testing.B) {
 	p := &SyncDelayReq{
 		Header: Header{
 			SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageSync, 1),
-			Version:             2,
+			Version:             MajorVersion,
 			MessageLength:       44,
 			DomainNumber:        0,
 			MinorSdoID:          0,
@@ -323,7 +323,7 @@ func BenchmarkWriteFollowup(b *testing.B) {
 	p := &FollowUp{
 		Header: Header{
 			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageFollowUp, 0),
-			Version:         Version,
+			Version:         MajorVersion,
 			MessageLength:   uint16(binary.Size(FollowUp{})),
 			DomainNumber:    0,
 			FlagField:       FlagUnicast,

--- a/protocol/ptp4l.go
+++ b/protocol/ptp4l.go
@@ -75,7 +75,7 @@ func PortStatsNPRequest() *Management {
 			Header: Header{
 				SdoIDAndMsgType:    NewSdoIDAndMsgType(MessageManagement, 0),
 				Version:            Version,
-				MessageLength:      headerSize + tlvHeadSize,
+				MessageLength:      headerSize + tlvHeadSize + 2,
 				SourcePortIdentity: identity,
 				LogMessageInterval: MgmtLogMessageInterval,
 			},
@@ -118,7 +118,7 @@ func TimeStatusNPRequest() *Management {
 			Header: Header{
 				SdoIDAndMsgType:    NewSdoIDAndMsgType(MessageManagement, 0),
 				Version:            Version,
-				MessageLength:      headerSize + tlvHeadSize,
+				MessageLength:      headerSize + tlvHeadSize + 2,
 				SourcePortIdentity: identity,
 				LogMessageInterval: MgmtLogMessageInterval,
 			},

--- a/protocol/ptp4l_test.go
+++ b/protocol/ptp4l_test.go
@@ -38,7 +38,7 @@ func Test_parseTimeStatusNP(t *testing.T) {
 		ManagementMsgHead: ManagementMsgHead{
 			Header: Header{
 				SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageManagement, 0),
-				Version:             2,
+				Version:             MajorVersion,
 				MessageLength:       uint16(len(raw) - 2),
 				DomainNumber:        0,
 				MinorSdoID:          0,


### PR DESCRIPTION
## Summary

* Bump to protocol version 2.1
* Fix custom management TLV msg lengths

This change is a result of testing our code with latest ptp4l built from git master 2021-11-03, and allows the code to properly work with it.

## Test Plan

The change is backwards compatible. I tested both ways:
* ptpcheck talking to both new and old ptp4l, both management proto and 'ptpcheck trace' which acts as a PTP client.
* ptp4l 3.1 works fine as a client for new ptp4u.