### PR TITLE
Add oscillatord package and ptpcheck subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,8 @@ go get github.com/facebookincubator/ptp/ptp4u
 ## Simpleclient
 Basic PTPv2.1 two-step unicast client implementation.
 
+## oscillatord
+Implementation of monitoring protocol used by Orolia [oscillatord](https://github.com/Orolia2s/oscillatord).
+
 # License
 PTP is licensed under Apache 2.0 as found in the [LICENSE file](LICENSE).

--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -1,0 +1,198 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package oscillatord implements monitoring protocol used by Orolia's oscillatord,
+daemon for disciplining an oscillator.
+
+All references throughout the code relate to the https://github.com/Orolia2s/oscillatord code.
+*/
+package oscillatord
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// AntennaStatus is an enum describing antenna status as reported by oscillatord
+type AntennaStatus int
+
+// from oscillatord src/gnss.c
+const (
+	AntStatusInit AntennaStatus = iota
+	AntStatusDontKnow
+	AntStatusOK
+	AntStatusSHORT
+	AntStatusOpen
+	AntStatusUndefined
+)
+
+var antennaStatusToString = map[AntennaStatus]string{
+	AntStatusInit:      "INIT",
+	AntStatusDontKnow:  "DONTKNOW",
+	AntStatusOK:        "OK",
+	AntStatusSHORT:     "SHORT",
+	AntStatusOpen:      "OPEN",
+	AntStatusUndefined: "UNDEFINED",
+}
+
+func (a AntennaStatus) String() string {
+	s, found := antennaStatusToString[a]
+	if !found {
+		return "UNSUPPORTED VALUE"
+	}
+	return s
+}
+
+// AntennaPower is an enum describing antenna power status as reported by oscillatord
+type AntennaPower int
+
+// from oscillatord src/gnss.c
+const (
+	AntPowerOff AntennaPower = iota
+	AntPowerOn
+	AntPowerDontKnow
+	AntPowerIdle
+	AntPowerUndefined
+)
+
+var antennaPowerToString = map[AntennaPower]string{
+	AntPowerOff:       "OFF",
+	AntPowerOn:        "ON",
+	AntPowerDontKnow:  "DONTKNOW",
+	AntPowerIdle:      "IDLE",
+	AntPowerUndefined: "UNDEFINED",
+}
+
+func (p AntennaPower) String() string {
+	s, found := antennaPowerToString[p]
+	if !found {
+		return "UNSUPPORTED VALUE"
+	}
+	return s
+}
+
+// GNSSFix is an enum describing GNSS fix status as reported by oscillatord
+type GNSSFix int
+
+// from oscillatord src/gnss.c
+const (
+	FixUnknown GNSSFix = iota
+	FixNoFix
+	FixDROnly
+	FixTime
+	Fix2D
+	Fix3D
+	Fix3DDr
+	FixRTKFloat
+	FixRTKFixed
+	FixFloatDr
+	FixFixedDr
+)
+
+var gnssFixToString = map[GNSSFix]string{
+	FixUnknown:  "Unknown",
+	FixNoFix:    "No fix",
+	FixDROnly:   "DR only",
+	FixTime:     "Time",
+	Fix2D:       "2D",
+	Fix3D:       "3D",
+	Fix3DDr:     "3D_DR",
+	FixRTKFloat: "RTK_FLOAT",
+	FixRTKFixed: "RTK_FIXED",
+	FixFloatDr:  "RTK_FLOAT_DR",
+	FixFixedDr:  "RTK_FIXED_DR",
+}
+
+func (f GNSSFix) String() string {
+	s, found := gnssFixToString[f]
+	if !found {
+		return "UNSUPPORTED VALUE"
+	}
+	return s
+}
+
+// LeapSecondChange is enum that oscillatord uses to indicate leap second change
+type LeapSecondChange int
+
+// from oscillatord src/gnss.c
+const (
+	LeapNoWarning LeapSecondChange = 0
+	LeapAddSecond LeapSecondChange = 1
+	LeapDelSecond LeapSecondChange = -1
+)
+
+var leapSecondChangeToString = map[LeapSecondChange]string{
+	LeapNoWarning: "NO WARNING",
+	LeapAddSecond: "ADD SECOND",
+	LeapDelSecond: "DEL SECOND",
+}
+
+func (c LeapSecondChange) String() string {
+	s, found := leapSecondChangeToString[c]
+	if !found {
+		return "UNSUPPORTED VALUE"
+	}
+	return s
+}
+
+// Oscillator describes structure that oscillatord returns for oscillator
+type Oscillator struct {
+	Model       string  `json:"model"`
+	FineCtrl    int     `json:"fine_ctrl"`
+	CoarseCtrl  int     `json:"coarse_ctrl"`
+	Lock        bool    `json:"lock"`
+	Temperature float64 `json:"temperature"`
+}
+
+// GNSS describes structure that oscillatord returns for gnss
+type GNSS struct {
+	Fix           GNSSFix          `json:"fix"`
+	FixOK         bool             `json:"fixOk"`
+	AntennaPower  AntennaPower     `json:"antenna_power"`
+	AntennaStatus AntennaStatus    `json:"antenna_status"`
+	LSChange      LeapSecondChange `json:"lsChange"`
+	LeapSeconds   int              `json:"leap_seconds"`
+}
+
+// Status is whole structure that oscillatord returns for monitoring
+type Status struct {
+	Oscillator Oscillator `json:"oscillator"`
+	GNSS       GNSS       `json:"gnss"`
+}
+
+// ReadStatus talks to oscillatord via monitoring port connection and reads reported Status
+func ReadStatus(conn io.ReadWriter) (*Status, error) {
+	// send newline to make oscillatord send us data
+	_, err := conn.Write([]byte{'\n'})
+	if err != nil {
+		return nil, fmt.Errorf("writing to oscillatord conn: %w", err)
+	}
+	buf := make([]byte, 1000)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, fmt.Errorf("reading from oscillatord conn: %w", err)
+	}
+	if n == 0 {
+		return nil, fmt.Errorf("read 0 bytes from oscillatord")
+	}
+	var status Status
+	if err := json.Unmarshal(buf[:n], &status); err != nil {
+		return nil, fmt.Errorf("unmarshalling JSON: %w", err)
+	}
+	return &status, nil
+}

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oscillatord
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOscillatordRead(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go func() {
+		// read newline
+		b := make([]byte, 1)
+		_, err := server.Read(b)
+		require.Nil(t, err)
+		// write response
+		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18 } }`
+		_, err = server.Write([]byte(data))
+		require.Nil(t, err)
+	}()
+	status, err := ReadStatus(client)
+	require.Nil(t, err)
+	want := &Status{
+		Oscillator: Oscillator{
+			Model:       "sa3x",
+			FineCtrl:    0,
+			CoarseCtrl:  0,
+			Lock:        false,
+			Temperature: 45.944,
+		},
+		GNSS: GNSS{
+			Fix:           Fix3D,
+			FixOK:         true,
+			AntennaPower:  AntPowerOn,
+			AntennaStatus: AntStatusOpen,
+			LSChange:      LeapNoWarning,
+			LeapSeconds:   18,
+		},
+	}
+	require.Equal(t, want, status)
+}
+
+func TestOscillatordReadFail(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	go func() {
+		// read newline
+		b := make([]byte, 1)
+		_, err := server.Read(b)
+		require.Nil(t, err)
+		server.Close()
+	}()
+	_, err := ReadStatus(client)
+	require.Error(t, err)
+}
+
+func TestOscillatordReadGarbage(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go func() {
+		// read newline
+		b := make([]byte, 1)
+		_, err := server.Read(b)
+		require.Nil(t, err)
+		// write response
+		data := `{ fdkfjd }`
+		_, err = server.Write([]byte(data))
+		require.Nil(t, err)
+	}()
+	_, err := ReadStatus(client)
+	require.Error(t, err)
+}

--- a/ptpcheck/cmd/oscillatord.go
+++ b/ptpcheck/cmd/oscillatord.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/facebookincubator/ptp/oscillatord"
+)
+
+var (
+	oscillatordPortFlag    int
+	oscillatordAddressFlag string
+	oscillatorJSONFlag     bool
+)
+
+func init() {
+	RootCmd.AddCommand(oscillatordCmd)
+	oscillatordCmd.Flags().StringVarP(&oscillatordAddressFlag, "address", "a", "127.0.0.1", "address to connect to")
+	oscillatordCmd.Flags().IntVarP(&oscillatordPortFlag, "port", "p", 2958, "port to connect to")
+	oscillatordCmd.Flags().BoolVarP(&oscillatorJSONFlag, "json", "j", false, "JSON output")
+}
+
+func bool2int(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func printOscillatordJSON(status *oscillatord.Status) error {
+	output := struct {
+		Temperature       int64 `json:"ptp.timecard.temperature"`
+		Lock              int64 `json:"ptp.timecard.lock"`
+		GNSSFixNum        int64 `json:"ptp.timecard.gnss.fix_num"`
+		GNSSFixOk         int64 `json:"ptp.timecard.gnss.fix_ok"`
+		GNSSAntennaPower  int64 `json:"ptp.timecard.gnss.antenna_power"`
+		GNSSAntennaStatus int64 `json:"ptp.timecard.gnss.antenna_status"`
+		GNSSLSChange      int64 `json:"ptp.timecard.gnss.leap_second_change"`
+		GNSSLeapSeconds   int64 `json:"ptp.timecard.gnss.leap_seconds"`
+	}{
+		Temperature:       int64(status.Oscillator.Temperature),
+		Lock:              bool2int(status.Oscillator.Lock),
+		GNSSFixNum:        int64(status.GNSS.Fix),
+		GNSSFixOk:         bool2int(status.GNSS.FixOK),
+		GNSSAntennaPower:  int64(status.GNSS.AntennaPower),
+		GNSSAntennaStatus: int64(status.GNSS.AntennaStatus),
+		GNSSLSChange:      int64(status.GNSS.LSChange),
+		GNSSLeapSeconds:   int64(status.GNSS.LeapSeconds),
+	}
+	toPrint, err := json.Marshal(output)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(toPrint))
+	return nil
+}
+
+func printOscillatord(status *oscillatord.Status) {
+	fmt.Println("Oscillator:")
+	fmt.Printf("\tmodel: %s\n", status.Oscillator.Model)
+	fmt.Printf("\tfine_ctrl: %d\n", status.Oscillator.FineCtrl)
+	fmt.Printf("\tcoarse_ctrl: %d\n", status.Oscillator.CoarseCtrl)
+	fmt.Printf("\tlock: %v\n", status.Oscillator.Lock)
+	fmt.Printf("\ttemperature: %.2fC\n", status.Oscillator.Temperature)
+
+	fmt.Println("GNSS:")
+	fmt.Printf("\tfix: %s (%d)\n", status.GNSS.Fix, status.GNSS.Fix)
+	fmt.Printf("\tfixOk: %v\n", status.GNSS.FixOK)
+	fmt.Printf("\tantenna_power: %s (%d)\n", status.GNSS.AntennaPower, status.GNSS.AntennaPower)
+	fmt.Printf("\tantenna_status: %s (%d)\n", status.GNSS.AntennaStatus, status.GNSS.AntennaStatus)
+	fmt.Printf("\tleap_second_change: %s (%d)\n", status.GNSS.LSChange, status.GNSS.LSChange)
+	fmt.Printf("\tleap_seconds: %d\n", status.GNSS.LeapSeconds)
+}
+
+func oscillatordRun(address string, jsonOut bool) error {
+	timeout := 1 * time.Second
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		return fmt.Errorf("connecting to oscillatord: %w", err)
+	}
+	defer conn.Close()
+	deadline := time.Now().Add(timeout)
+	if err := conn.SetDeadline(deadline); err != nil {
+		return fmt.Errorf("setting connection deadline: %w", err)
+	}
+
+	status, err := oscillatord.ReadStatus(conn)
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		return printOscillatordJSON(status)
+	}
+
+	printOscillatord(status)
+
+	return nil
+}
+
+var oscillatordCmd = &cobra.Command{
+	Use:   "oscillatord",
+	Short: "Print Time Card stats reported by oscillatord",
+	Run: func(c *cobra.Command, args []string) {
+		ConfigureVerbosity()
+		address := net.JoinHostPort(oscillatordAddressFlag, fmt.Sprint(oscillatordPortFlag))
+		if err := oscillatordRun(address, oscillatorJSONFlag); err != nil {
+			log.Fatal(err)
+		}
+	},
+}


### PR DESCRIPTION
## Summary

* implementation of the monitoring protocol used by https://github.com/Orolia2s/oscillatord
* `ptpcheck oscillatord` subcommand to expose the data in human-readable and flat JSON form

## Test Plan

unittests

human-readable
```
[root@timeserver ~]# ./ptpcheck oscillatord
Oscillator:
        model: sa3x
        fine_ctrl: 0
        coarse_ctrl: 0
        lock: false
        temperature: 46.60C
GNSS:
        fix: 3D (5)
        fixOk: true
        antenna_power: ON (1)
        antenna_status: OPEN (4)
        leap_second_change: NO WARNING (0)
        leap_seconds: 18
```

json
```
[root@timeserver ~]# ./ptpcheck oscillatord --json
{"ptp.timecard.temperature":46,"ptp.timecard.lock":0,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18}
```
