### PR TITLE
Fix TestSocketControlMessageTimestamp for platforms different from amd64

### DIFF
--- a/protocol/timestamp.go
+++ b/protocol/timestamp.go
@@ -48,8 +48,10 @@ const (
 	// look only for X sequential TS
 	maxTXTS = 100
 	// Socket Control Message Header Offset on Linux
-	SocketControlMessageHeaderOffset = 16
 )
+
+// unix.Cmsghdr size differs depending on platform
+var socketControlMessageHeaderOffset = binary.Size(unix.Cmsghdr{})
 
 const (
 	// HWTIMESTAMP is a hardware timestamp
@@ -177,7 +179,7 @@ func socketControlMessageTimestamp(b []byte) (time.Time, error) {
 
 		// depending on the kernel version, when we ask for SO_TIMESTAMPING_NEW we still might get messages with type SO_TIMESTAMPING
 		if h.Level == unix.SOL_SOCKET && int(h.Type) == unix.SO_TIMESTAMPING_NEW || int(h.Type) == unix.SO_TIMESTAMPING {
-			return scmDataToTime(b[i+SocketControlMessageHeaderOffset : i+mlen])
+			return scmDataToTime(b[i+socketControlMessageHeaderOffset : i+mlen])
 		}
 	}
 	return time.Time{}, fmt.Errorf("failed to find timestamp in socket control message")

--- a/protocol/timestamp_test.go
+++ b/protocol/timestamp_test.go
@@ -19,6 +19,7 @@ package protocol
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -147,18 +148,24 @@ func TestSockaddrToIP(t *testing.T) {
 	require.Equal(t, ip6.String(), SockaddrToIP(sa6).String())
 }
 
-/*
-o: [60 0 0 0 0 0 0 0 41 0 0 0 25 0 0 0 42 0 0 0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 64 0 0 0 0 0 0 0 1 0 0 0 65 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 230 180 10 97 0 0 0 0 239 83 199 39 0 0 0 0 ]
-Data [{Header:{Len:60 Level:41 Type:25} Data:[42 0 0 0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}, {Header:{Len:64 Level:1 Type:65} Data:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 230 180 10 97 0 0 0 0 239 83 199 39 0 0 0 0]}]
-*/
 func TestSocketControlMessageTimestamp(t *testing.T) {
 	if timestamping != unix.SO_TIMESTAMPING_NEW {
 		t.Skip("This test supports SO_TIMESTAMPING_NEW only. No sample of SO_TIMESTAMPING")
 	}
 
-	b := []byte{60, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 25, 0, 0, 0, 42, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 230, 180, 10, 97, 0, 0, 0, 0, 239, 83, 199, 39, 0, 0, 0, 0}
+	var b []byte
+
+	// unix.Cmsghdr used in socketControlMessageTimestamp differs depending on platform
+	switch runtime.GOARCH {
+	case "amd64":
+		b = []byte{60, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 25, 0, 0, 0, 42, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 230, 180, 10, 97, 0, 0, 0, 0, 239, 83, 199, 39, 0, 0, 0, 0}
+	case "386":
+		b = []byte{56, 0, 0, 0, 41, 0, 0, 0, 25, 0, 0, 0, 42, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 60, 0, 0, 0, 1, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 230, 180, 10, 97, 0, 0, 0, 0, 239, 83, 199, 39, 0, 0, 0, 0}
+	default:
+		t.Skip("This test supports amd64/386 platforms only")
+	}
+
 	ts, err := socketControlMessageTimestamp(b)
 	require.NoError(t, err)
 	require.Equal(t, int64(1628091622667374575), ts.UnixNano())
-
 }


### PR DESCRIPTION
## Summary

`unix.Cmsghdr` used in `socketControlMessageTimestamp` has different size depending on the platform.
```
--- FAIL: TestSocketControlMessageTimestamp (0.00s)
    timestamp_test.go:161: 
        	Error Trace:	timestamp_test.go:161
        	Error:      	Received unexpected error:
        	            	failed to find timestamp in socket control message
        	Test:       	TestSocketControlMessageTimestamp
```


## Test Plan

amd64
```
> go test github.com/facebookincubator/ptp/protocol/... -run TestSocketControlMessageTimestamp -v
=== RUN   TestSocketControlMessageTimestamp
--- PASS: TestSocketControlMessageTimestamp (0.00s)
PASS
ok      github.com/facebookincubator/ptp/protocol       0.004s
```

386
```
> GOARCH=386 go test github.com/facebookincubator/ptp/protocol/... -run TestSocketControlMessageTimestamp -v
=== RUN   TestSocketControlMessageTimestamp
--- PASS: TestSocketControlMessageTimestamp (0.00s)
PASS
ok      github.com/facebookincubator/ptp/protocol       0.003s
```